### PR TITLE
feat: remove SOCKS5 roundtrip

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,15 @@
 > interested in integrating with it, we'd love your [feedback](https://github.com/Jigsaw-Code/outline-sdk/issues/new).
 
 The Outline SDK allows you to:
+
 - Create tools to protect against network-level interference
 - Add network-level interference protection to existing apps, such as content or communication apps
-
 
 ## Advantages
 
 | Multi-Platform | Proven Technology | Composable |
 |:-:|:-:|:-:|
 | The Outline SDK can be used to build tools that run on Android, iOS, Windows, macOS and Linux. | The Outline Client and Server have been using the code in the SDK for years, helping millions of users access the internet in even the harshest conditions. | The SDK interfaces were carefully designed to allow for composition and reuse, so you can craft your own transport. |
-
 
 ## Integration
 
@@ -34,11 +33,9 @@ The Outline SDK is written in Go. There are multiple ways to integrate the Outli
 
 The Outline Client uses the mobile library approach on Android, iOS and macOS (based on Cordova) and the side service on Windows and Linux (based on Electron).
 
-
 ## Tentative Roadmap
 
 The launch will have two milestones: Alpha and Beta. We are currently in Alpha. Most of the code is not new. It's the same code that is currently being used by the production Outline Client and Server. The SDK repackages code from [outline-ss-server](https://github.com/Jigsaw-Code/outline-ss-server) and [outline-go-tun2socks](https://github.com/Jigsaw-Code/outline-go-tun2socks) in a way that is easier to reuse and extend.
-
 
 ### Alpha
 
@@ -51,14 +48,13 @@ Alpha features:
   - [x] Add TCP and UDP client implementations
   - [x] Add Shadowsocks client implementations
   - [x] Use transport libraries in the Outline Client
-  - [x] Use transport libraries in the Outline Server 
+  - [x] Use transport libraries in the Outline Server
 
 - Network-level libraries
   - [x] Add IP Device abstraction
   - [x] Add IP Device implementation based on go-tun2socks (LWIP)
   - [x] Add UDP handler to fallback to DNS-over-TCP
   - [x] Add DelegatePacketProxy for runtime PacketProxy replacement
-
 
 ### Beta
 
@@ -76,7 +72,8 @@ Beta features:
 
 - Proxy transport libraries
   - [ ] HTTP Connect
-  - [ ] SOCKS5
+  - [x] SOCKS5 StreamDialer
+  - [ ] SOCKS5 PacketDialer
 
 - Add Resources
   - [ ] Website

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/shadowsocks/go-shadowsocks2 v0.1.5
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/crypto v0.7.0
-	golang.org/x/net v0.8.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191021144547-ec77196f6094/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
-golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/transport/socks5/socks5.go
+++ b/transport/socks5/socks5.go
@@ -47,7 +47,7 @@ func appendSOCKS5Address(b []byte, address string) ([]byte, error) {
 		}
 	} else {
 		if len(host) > 255 {
-			return nil, fmt.Errorf("FQDN length (%v) is over 255", len(host))
+			return nil, fmt.Errorf("domain name length = %v is over 255", len(host))
 		}
 		b = append(b, addrTypeDomainName)
 		b = append(b, byte(len(host)))

--- a/transport/socks5/socks5.go
+++ b/transport/socks5/socks5.go
@@ -1,0 +1,58 @@
+// Copyright 2023 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package socks5
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+)
+
+const addrTypeIPv4 = 0x01
+const addrTypeDomainName = 0x03
+const addrTypeIPv6 = 0x04
+
+func appendSOCKS5Address(b []byte, address string) ([]byte, error) {
+	host, portStr, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	portNum, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, err
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			b = append(b, addrTypeIPv4)
+			b = append(b, ip4...)
+		} else if ip6 := ip.To16(); ip6 != nil {
+			b = append(b, addrTypeIPv6)
+			b = append(b, ip6...)
+		} else {
+			// This should never happen.
+			return nil, errors.New("IP address not IPv4 or IPv6")
+		}
+	} else {
+		if len(host) > 255 {
+			return nil, fmt.Errorf("FQDN length (%v) is over 255", len(host))
+		}
+		b = append(b, addrTypeDomainName)
+		b = append(b, byte(len(host)))
+		b = append(b, host...)
+	}
+	b = append(b, byte(portNum>>8), byte(portNum))
+	return b, nil
+}

--- a/transport/socks5/socks5_test.go
+++ b/transport/socks5/socks5_test.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package socks5
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendSOCKS5Address_IPv4(t *testing.T) {
+	b := []byte{}
+	b, err := appendSOCKS5Address(b, "8.8.8.8:853")
+	require.NoError(t, err)
+	// 853 = 0x355
+	require.EqualValues(t, []byte{1, 8, 8, 8, 8, 0x3, 0x55}, b)
+}
+
+func TestAppendSOCKS5Address_IPv6(t *testing.T) {
+	b := []byte{}
+	b, err := appendSOCKS5Address(b, "[2001:4860:4860::8888]:853")
+	require.NoError(t, err)
+	require.EqualValues(t, []byte{0x04, 0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0, 0, 0, 0, 0, 0, 0, 0, 0x88, 0x88, 0x3, 0x55}, b)
+}
+
+func TestAppendSOCKS5Address_DomainName(t *testing.T) {
+	b := []byte{}
+	b, err := appendSOCKS5Address(b, "dns.google:853")
+	require.NoError(t, err)
+	require.EqualValues(t, []byte{0x03, byte(len("dns.google")), 'd', 'n', 's', '.', 'g', 'o', 'o', 'g', 'l', 'e', 0x3, 0x55}, b)
+}
+
+func TestAppendSOCKS5Address_NotHostPort(t *testing.T) {
+	_, err := appendSOCKS5Address([]byte{}, "fsdfksajdhfjk")
+	require.Error(t, err)
+}
+
+func TestAppendSOCKS5Address_BadPort(t *testing.T) {
+	_, err := appendSOCKS5Address([]byte{}, "dns.google:dns")
+	require.Error(t, err)
+}
+
+func TestAppendSOCKS5Address_DomainNameTooLong(t *testing.T) {
+	_, err := appendSOCKS5Address([]byte{}, strings.Repeat("1234567890", 26)+":53")
+	require.Error(t, err)
+}

--- a/transport/socks5/stream_dialer.go
+++ b/transport/socks5/stream_dialer.go
@@ -53,7 +53,7 @@ func (c *StreamDialer) Dial(ctx context.Context, remoteAddr string) (transport.S
 
 	// For protocol details, see https://datatracker.ietf.org/doc/html/rfc1928#autoid-3
 
-	// Buffer large enough for a FQDN address
+	// Buffer large enough for a domain name address
 	header := [3 + 4 + 256 + 2]byte{}
 
 	// Method request:

--- a/transport/socks5/stream_dialer.go
+++ b/transport/socks5/stream_dialer.go
@@ -1,0 +1,125 @@
+// Copyright 2023 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package socks5
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+)
+
+// NewStreamDialer creates a client that routes connections to a SOCKS5 proxy listening at
+// the given [transport.StreamEndpoint].
+func NewStreamDialer(endpoint transport.StreamEndpoint) (transport.StreamDialer, error) {
+	// See https://pkg.go.dev/golang.org/x/net/proxy#SOCKS5
+	if endpoint == nil {
+		return nil, errors.New("argument endpoint must not be nil")
+	}
+	return &StreamDialer{proxyEndpoint: endpoint}, nil
+}
+
+type StreamDialer struct {
+	proxyEndpoint transport.StreamEndpoint
+}
+
+var _ transport.StreamDialer = (*StreamDialer)(nil)
+
+func (c *StreamDialer) Dial(ctx context.Context, remoteAddr string) (transport.StreamConn, error) {
+	proxyConn, err := c.proxyEndpoint.Connect(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to SOCKS5 proxy: %w", err)
+	}
+	dialSuccess := false
+	defer func() {
+		if !dialSuccess {
+			proxyConn.Close()
+		}
+	}()
+
+	// For protocol details, see https://datatracker.ietf.org/doc/html/rfc1928#autoid-3
+
+	// Buffer large enough for a FQDN address
+	header := [3 + 4 + 256 + 2]byte{}
+
+	// Method request:
+	// VER = 5, NMETHODS = 1, METHODS = 0 (no auth)
+	b := append(header[0:0], 5, 1, 0)
+
+	// Connect request:
+	// VER = 5, CMD = 1 (connect), RSV = 0
+	b = append(b, 5, 1, 0)
+	// Destination address Address (ATYP, DST.ADDR, DST.PORT)
+	b, err = appendSOCKS5Address(b, remoteAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SOCKS5 address: %w", err)
+	}
+
+	// We merge the method and connect requests because we send a single authentication
+	// method, so there's no point in waiting for the response. This eliminates a roundtrip.
+	_, err = proxyConn.Write(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write SOCKS5 request: %w", err)
+	}
+
+	// Read method response (VER, METHOD).
+	if _, err = io.ReadFull(proxyConn, header[:2]); err != nil {
+		return nil, fmt.Errorf("failed to read method server response")
+	}
+	if header[0] != 5 {
+		return nil, fmt.Errorf("invalid protocol version %v. Expected 5", header[0])
+	}
+	if header[1] != 0 {
+		return nil, fmt.Errorf("unsupported SOCKS authentication method %v. Expected 0 (no auth)", header[1])
+	}
+
+	// Read connect response (VER, REP, RSV, ATYP, BND.ADDR, BND.PORT).
+	// See https://datatracker.ietf.org/doc/html/rfc1928#section-6.
+	if _, err = io.ReadFull(proxyConn, header[:4]); err != nil {
+		return nil, fmt.Errorf("failed to read connect server response")
+	}
+	if header[0] != 5 {
+		return nil, fmt.Errorf("invalid protocol version %v. Expected 5", header[0])
+	}
+	toRead := 0
+	switch header[3] {
+	case addrTypeIPv4:
+		toRead = 4
+	case addrTypeIPv6:
+		toRead = 16
+	case addrTypeDomainName:
+		_, err := io.ReadFull(proxyConn, header[:1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to read address length in connect response: %w", err)
+		}
+		toRead = int(header[0])
+	}
+	// Reads the bound address and port, but we currently ignore them.
+	// TODO(fortuna): Should we expose the remote bound address as the net.Conn.LocalAddr()?
+	_, err = io.ReadFull(proxyConn, header[:toRead])
+	if err != nil {
+		return nil, fmt.Errorf("failed to read address in connect response: %w", err)
+	}
+	// We also ignore the remote bound port number.
+	_, err = io.ReadFull(proxyConn, header[:2])
+	if err != nil {
+		return nil, fmt.Errorf("failed to read port number in connect response: %w", err)
+	}
+
+	dialSuccess = true
+	return proxyConn, nil
+}

--- a/transport/socks5/stream_dialer.go
+++ b/transport/socks5/stream_dialer.go
@@ -38,7 +38,8 @@ type streamDialer struct {
 
 var _ transport.StreamDialer = (*streamDialer)(nil)
 
-// Dial implements [transport.StreamDialer].Dial
+// Dial implements [transport.StreamDialer].Dial using SOCKS5.
+// It will send the method and the connect requests in one packet, to avoid an unnecessary roundtrip.
 func (c *streamDialer) Dial(ctx context.Context, remoteAddr string) (transport.StreamConn, error) {
 	proxyConn, err := c.proxyEndpoint.Connect(ctx)
 	if err != nil {

--- a/transport/socks5/stream_dialer.go
+++ b/transport/socks5/stream_dialer.go
@@ -51,7 +51,7 @@ func (c *streamDialer) Dial(ctx context.Context, remoteAddr string) (transport.S
 		}
 	}()
 
-	// For protocol details, see https://datatracker.ietf.org/doc/html/rfc1928#autoid-3
+	// For protocol details, see https://datatracker.ietf.org/doc/html/rfc1928#section-3
 
 	// Buffer large enough for method and connect requests with a domain name address
 	header := [3 + 4 + 256 + 2]byte{}

--- a/transport/socks5/stream_dialer_test.go
+++ b/transport/socks5/stream_dialer_test.go
@@ -1,0 +1,127 @@
+// Copyright 2023 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package socks5
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"testing/iotest"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSOCKS5Dialer_NewStreamDialerNil(t *testing.T) {
+	dialer, err := NewStreamDialer(nil)
+	require.Nil(t, dialer)
+	require.Error(t, err)
+}
+
+func TestSOCKS5Dialer_BadConnection(t *testing.T) {
+	dialer, err := NewStreamDialer(&transport.TCPEndpoint{Address: "127.0.0.0:0"})
+	require.NotNil(t, dialer)
+	require.NoError(t, err)
+	_, err = dialer.Dial(context.Background(), "example.com:443")
+	require.Error(t, err)
+}
+
+func TestSOCKS5Dialer_BadAddress(t *testing.T) {
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err, "Failed to create TCP listener: %v", err)
+	defer listener.Close()
+
+	dialer, err := NewStreamDialer(&transport.TCPEndpoint{Address: listener.Addr().String()})
+	require.NotNil(t, dialer)
+	require.NoError(t, err)
+
+	_, err = dialer.Dial(context.Background(), "noport")
+	require.Error(t, err)
+}
+
+func TestSOCKS5Dialer_Dial(t *testing.T) {
+	requestText := []byte("Request")
+	responseText := []byte("Response")
+
+	for _, destAddress := range []string{"example.com:443", "8.8.8.8:444", "[2001:4860:4860::8888]:853"} {
+		t.Run(fmt.Sprintf("addr=%v", destAddress), func(t *testing.T) {
+			listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
+			require.NoError(t, err, "Failed to create TCP listener: %v", err)
+			defer listener.Close()
+
+			var running sync.WaitGroup
+			running.Add(2)
+
+			// Client
+			go func() {
+				defer running.Done()
+				dialer, err := NewStreamDialer(&transport.TCPEndpoint{Address: listener.Addr().String()})
+				require.NoError(t, err)
+				serverConn, err := dialer.Dial(context.Background(), destAddress)
+				require.NoError(t, err, "Dial failed")
+				require.Equal(t, listener.Addr().String(), serverConn.RemoteAddr().String())
+				defer serverConn.Close()
+
+				n, err := serverConn.Write(requestText)
+				require.NoError(t, err)
+				require.Equal(t, len(requestText), n)
+				assert.NoError(t, serverConn.CloseWrite())
+
+				err = iotest.TestReader(serverConn, responseText)
+				require.NoError(t, err, "Response read failed: %v", err)
+			}()
+
+			// Server
+			go func() {
+				defer running.Done()
+				clientConn, err := listener.AcceptTCP()
+				require.NoError(t, err, "AcceptTCP failed: %v", err)
+				defer clientConn.Close()
+
+				// See https://datatracker.ietf.org/doc/html/rfc1928#autoid-3
+				// This reads method and connect requests at once, demonstrating they are both sent before a server response.
+				// Method request: VER = 5, NMETHODS = 1, METHODS = 0 (no auth)
+				// Connect request: VER = 5, CMD = 1, RSV = 0, ATYP, DST.ADDR, DST.PORT
+				expected := []byte{5, 1, 0, 5, 1, 0}
+				expected, err = appendSOCKS5Address(expected, destAddress)
+				require.NoError(t, err)
+				err = iotest.TestReader(io.LimitReader(clientConn, int64(len(expected))), expected)
+				assert.NoError(t, err, "Request read failed: %v", err)
+
+				// Write the method and connect responses
+				// Method response: VER = 5, METHOD = 0
+				// Connect response: VER = 5, REP = 0 (success), RSV = 0, ATYP = 1 (IPv4), BND.ADDR, BND.PORT
+				_, err = clientConn.Write([]byte{5, 0, 5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+				assert.NoError(t, err, "Write failed: %v", err)
+
+				err = iotest.TestReader(clientConn, requestText)
+				assert.NoError(t, err, "Request read failed: %v", err)
+
+				n, err := clientConn.Write(responseText)
+				require.NoError(t, err)
+				require.Equal(t, len(responseText), n)
+
+				err = clientConn.CloseWrite()
+				assert.NoError(t, err, "CloseWrite failed: %v", err)
+			}()
+
+			running.Wait()
+		})
+	}
+}


### PR DESCRIPTION
This PR is a rewrite of the SOCKS5 code to no longer use x/proxy.
Now we can sent the method and the connect requests in one write, avoiding a roundtrip.

Later, our rewrite will allow us to merge initial client data with the connection, making the initial packet size less predictable, like we do for Shadowsocks: https://github.com/Jigsaw-Code/outline-sdk/blob/ab1e88d4a2f9057c7096dec360f477086b9a62ef/transport/shadowsocks/stream_dialer.go#L93

We still need to figure out how to properly handle this kind of merging in a way that is reusable across dialers. Currently the Shadowsocks dialer has its own implementation.