### PR TITLE
feat: make config available in x/config and enable split and nesting support

### DIFF
--- a/x/config/shadowsocks.go
+++ b/x/config/shadowsocks.go
@@ -1,0 +1,102 @@
+// Copyright 2023 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+	"github.com/Jigsaw-Code/outline-sdk/transport/shadowsocks"
+)
+
+func newShadowsocksStreamDialerFromURL(innerDialer transport.StreamDialer, configURL *url.URL) (transport.StreamDialer, error) {
+	config, err := parseShadowsocksURL(configURL)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := &transport.StreamDialerEndpoint{Dialer: innerDialer, Address: config.serverAddress}
+	dialer, err := shadowsocks.NewStreamDialer(endpoint, config.cryptoKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(config.prefix) > 0 {
+		dialer.SaltGenerator = shadowsocks.NewPrefixSaltGenerator(config.prefix)
+	}
+	return dialer, nil
+}
+
+func newShadowsocksPacketDialerFromURL(innerDialer transport.PacketDialer, configURL *url.URL) (transport.PacketDialer, error) {
+	config, err := parseShadowsocksURL(configURL)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := &transport.PacketDialerEndpoint{Dialer: innerDialer, Address: config.serverAddress}
+	listener, err := shadowsocks.NewPacketListener(endpoint, config.cryptoKey)
+	if err != nil {
+		return nil, err
+	}
+	dialer := transport.PacketListenerDialer{Listener: listener}
+	return dialer, nil
+}
+
+type shadowsocksConfig struct {
+	serverAddress string
+	cryptoKey     *shadowsocks.EncryptionKey
+	prefix        []byte
+}
+
+func parseShadowsocksURL(url *url.URL) (*shadowsocksConfig, error) {
+	config := &shadowsocksConfig{}
+	if url.Host == "" {
+		return nil, errors.New("host not specified")
+	}
+	config.serverAddress = url.Host
+	cipherInfoBytes, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(url.User.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode cipher info [%v]: %w", url.User.String(), err)
+	}
+	cipherName, secret, found := strings.Cut(string(cipherInfoBytes), ":")
+	if !found {
+		return nil, errors.New("invalid cipher info: no ':' separator")
+	}
+	config.cryptoKey, err = shadowsocks.NewEncryptionKey(cipherName, secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+	prefixStr := url.Query().Get("prefix")
+	if len(prefixStr) > 0 {
+		config.prefix, err = parseStringPrefix(prefixStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse prefix: %w", err)
+		}
+	}
+	return config, nil
+}
+
+func parseStringPrefix(utf8Str string) ([]byte, error) {
+	runes := []rune(utf8Str)
+	rawBytes := make([]byte, len(runes))
+	for i, r := range runes {
+		if (r & 0xFF) != r {
+			return nil, fmt.Errorf("character out of range: %d", r)
+		}
+		rawBytes[i] = byte(r)
+	}
+	return rawBytes, nil
+}

--- a/x/examples/http2transport/main.go
+++ b/x/examples/http2transport/main.go
@@ -33,7 +33,7 @@ func main() {
 	addrFlag := flag.String("localAddr", "localhost:1080", "Local proxy address")
 	flag.Parse()
 
-	dialer, err := config.MakeStreamDialer(*transportFlag)
+	dialer, err := config.NewStreamDialer(*transportFlag)
 	if err != nil {
 		log.Fatalf("Could not create dialer: %v", err)
 	}

--- a/x/examples/http2transport/main.go
+++ b/x/examples/http2transport/main.go
@@ -24,7 +24,7 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/Jigsaw-Code/outline-sdk/x/examples/internal/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/config"
 	"github.com/Jigsaw-Code/outline-sdk/x/httpproxy"
 )
 

--- a/x/examples/outline-connectivity/main.go
+++ b/x/examples/outline-connectivity/main.go
@@ -27,8 +27,8 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
+	"github.com/Jigsaw-Code/outline-sdk/x/config"
 	"github.com/Jigsaw-Code/outline-sdk/x/connectivity"
-	"github.com/Jigsaw-Code/outline-sdk/x/examples/internal/config"
 )
 
 var debugLog log.Logger = *log.New(io.Discard, "", 0)

--- a/x/examples/outline-connectivity/main.go
+++ b/x/examples/outline-connectivity/main.go
@@ -116,14 +116,14 @@ func main() {
 			var testDuration time.Duration
 			switch proto {
 			case "tcp":
-				streamDialer, err := config.MakeStreamDialer(*transportFlag)
+				streamDialer, err := config.NewStreamDialer(*transportFlag)
 				if err != nil {
 					log.Fatalf("Failed to create StreamDialer: %v", err)
 				}
 				resolver := &transport.StreamDialerEndpoint{Dialer: streamDialer, Address: resolverAddress}
 				testDuration, testErr = connectivity.TestResolverStreamConnectivity(context.Background(), resolver, *domainFlag)
 			case "udp":
-				packetDialer, err := config.MakePacketDialer(*transportFlag)
+				packetDialer, err := config.NewPacketDialer(*transportFlag)
 				if err != nil {
 					log.Fatalf("Failed to create PacketDialer: %v", err)
 				}

--- a/x/examples/outline-fetch/main.go
+++ b/x/examples/outline-fetch/main.go
@@ -37,7 +37,7 @@ func main() {
 		log.Fatal("Need to pass the URL to fetch in the command-line")
 	}
 
-	dialer, err := config.MakeStreamDialer(*transportFlag)
+	dialer, err := config.NewStreamDialer(*transportFlag)
 	if err != nil {
 		log.Fatalf("Could not create dialer: %v", err)
 	}

--- a/x/examples/outline-fetch/main.go
+++ b/x/examples/outline-fetch/main.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Jigsaw-Code/outline-sdk/x/examples/internal/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/config"
 )
 
 func main() {

--- a/x/go.mod
+++ b/x/go.mod
@@ -3,7 +3,7 @@ module github.com/Jigsaw-Code/outline-sdk/x
 go 1.20
 
 require (
-	github.com/Jigsaw-Code/outline-sdk v0.0.4
+	github.com/Jigsaw-Code/outline-sdk v0.0.6
 	github.com/miekg/dns v1.1.54
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/sys v0.8.0

--- a/x/go.sum
+++ b/x/go.sum
@@ -1,5 +1,5 @@
-github.com/Jigsaw-Code/outline-sdk v0.0.4 h1:CBOGoxp3sW9vUZqZc66hF8lX9Fak8nEy22tBDDsZ/l4=
-github.com/Jigsaw-Code/outline-sdk v0.0.4/go.mod h1:hhlKz0+r9wSDFT8usvN8Zv/BFToCIFAUn1P2Qk8G2CM=
+github.com/Jigsaw-Code/outline-sdk v0.0.6 h1:8QqbfgMrdqU7LuUIrkoBev5O5I4u3tORe3RGJcCGOJ4=
+github.com/Jigsaw-Code/outline-sdk v0.0.6/go.mod h1:hhlKz0+r9wSDFT8usvN8Zv/BFToCIFAUn1P2Qk8G2CM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
We can now do stuff like this:
```
go run ./x/examples/outline-fetch/main.go -transport 'split:3|ss://[REDACTED]@[HOST]:80' https://example.com
```
or
```
go run ./x/examples/outline-fetch/main.go -transport 'split:3|split:132' https://example.com
```

@daniellacosse this should make the library accessible by your connectivity app.