### PR TITLE
chore: cleanup tools

### DIFF
--- a/x/examples/fetch/README.md
+++ b/x/examples/fetch/README.md
@@ -5,7 +5,7 @@ This app illustrates how to use different transports to fetch a URL in Go.
 Direct fetch:
 
 ```sh
-$ go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-fetch@latest https://ipinfo.io
+$ go run github.com/Jigsaw-Code/outline-sdk/x/examples/fetch@latest https://ipinfo.io
 {
   ...
   "city": "Amsterdam",
@@ -18,7 +18,7 @@ $ go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-fetch@latest http
 Using a Shadowsocks server:
 
 ```sh
-$ go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-fetch@latest -transport ss://[redacted]@[redacted]:80 https://ipinfo.io
+$ go run github.com/Jigsaw-Code/outline-sdk/x/examples/fetch@latest -transport ss://[redacted]@[redacted]:80 https://ipinfo.io
 {
   ...
   "region": "New Jersey",
@@ -31,7 +31,7 @@ $ go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-fetch@latest -tra
 Using a SOCKS5 server:
 
 ```sh
-$ go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-fetch@latest -transport socks5://[redacted]:5703 https://ipinfo.io
+$ go run github.com/Jigsaw-Code/outline-sdk/x/examples/fetch@latest -transport socks5://[redacted]:5703 https://ipinfo.io
 {
   ... 
   "city": "Berlin",
@@ -44,7 +44,7 @@ $ go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-fetch@latest -tra
 Using packet splitting:
 
 ```sh
-$ go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-fetch@latest -transport split:3  https://ipinfo.io
+$ go run github.com/Jigsaw-Code/outline-sdk/x/examples/fetch@latest -transport split:3  https://ipinfo.io
 {
   ...
   "city": "Amsterdam",

--- a/x/examples/outline-connectivity/main.go
+++ b/x/examples/outline-connectivity/main.go
@@ -19,10 +19,12 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -83,12 +85,19 @@ func unwrapAll(err error) error {
 	}
 }
 
+func init() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [flags...]\n", path.Base(os.Args[0]))
+		flag.PrintDefaults()
+	}
+}
+
 func main() {
 	verboseFlag := flag.Bool("v", false, "Enable debug output")
 	transportFlag := flag.String("transport", "", "Transport config")
 	domainFlag := flag.String("domain", "example.com.", "Domain name to resolve in the test")
 	resolverFlag := flag.String("resolver", "8.8.8.8,2001:4860:4860::8888", "Comma-separated list of addresses of DNS resolver to use for the test")
-	protoFlag := flag.String("proto", "tcp,udp", "Comma-separated list of the protocols to test. Muse be \"tcp\", \"udp\", or a combination of them")
+	protoFlag := flag.String("proto", "tcp,udp", "Comma-separated list of the protocols to test. Must be \"tcp\", \"udp\", or a combination of them")
 
 	flag.Parse()
 	if *verboseFlag {


### PR DESCRIPTION
Clean up tools:

- More outline-fetch to fetch. `outline-` is redundant and makes commands longer
- Add response headers to verbose output
- Fix and improve usage strings
