### PR TITLE
Send connectivity test result to specified report collector

### DIFF
--- a/x/examples/outline-connectivity/README.md
+++ b/x/examples/outline-connectivity/README.md
@@ -6,7 +6,8 @@ Example:
 ```
 # From https://www.reddit.com/r/outlinevpn/wiki/index/prefixing/
 KEY=ss://ENCRYPTION_KEY@HOST:PORT/
+COLLECTOR_URL=https://collector.example.com/metrics
 for PREFIX in POST%20 HTTP%2F1.1%20 %05%C3%9C_%C3%A0%01%20 %16%03%01%40%00%01 %13%03%03%3F %16%03%03%40%00%02; do
-  go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-connectivity@latest -transport="$KEY?prefix=$PREFIX" -proto tcp -resolver 8.8.8.8 && echo Prefix "$PREFIX" works!
+  go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-connectivity@latest -transport="$KEY?prefix=$PREFIX" -proto tcp -resolver 8.8.8.8 -port 53 -report-to $COLLECTOR_URL -report-success-rate 0.2 -report-failure-rate 1.0 && echo Prefix "$PREFIX" works!
 done
 ```

--- a/x/examples/outline-connectivity/README.md
+++ b/x/examples/outline-connectivity/README.md
@@ -8,6 +8,6 @@ Example:
 KEY=ss://ENCRYPTION_KEY@HOST:PORT/
 COLLECTOR_URL=https://collector.example.com/metrics
 for PREFIX in POST%20 HTTP%2F1.1%20 %05%C3%9C_%C3%A0%01%20 %16%03%01%40%00%01 %13%03%03%3F %16%03%03%40%00%02; do
-  go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-connectivity@latest -transport="$KEY?prefix=$PREFIX" -proto tcp -resolver 8.8.8.8 -port 53 -report-to $COLLECTOR_URL -report-success-rate 0.2 -report-failure-rate 1.0 && echo Prefix "$PREFIX" works!
+  go run github.com/Jigsaw-Code/outline-sdk/x/examples/outline-connectivity@latest -transport="$KEY?prefix=$PREFIX" -proto tcp -resolver 8.8.8.8 -report-to $COLLECTOR_URL -report-success-rate 0.2 -report-failure-rate 1.0 && echo Prefix "$PREFIX" works!
 done
 ```

--- a/x/examples/outline-connectivity/main.go
+++ b/x/examples/outline-connectivity/main.go
@@ -213,18 +213,17 @@ func main() {
 			// Send error report to collector if specified
 			if *reportToFlag != "" {
 				var samplingRate float64
-				if !success {
-					samplingRate = *reportFailureFlag
-				} else {
+				if success {
 					samplingRate = *reportSuccessFlag
+				} else {
+					samplingRate = *reportFailureFlag
 				}
 				// Generate a random number between 0 and 1
 				random := rand.Float64()
 				if random < samplingRate {
-					// Run your function here
 					err = sendReport(record, *reportToFlag)
 					if err != nil {
-						log.Fatalf("HTTP request failed: %v", err)
+						log.Fatalf("Report failed: %v", err)
 					} else {
 						fmt.Println("Report sent")
 					}

--- a/x/examples/outline-connectivity/main.go
+++ b/x/examples/outline-connectivity/main.go
@@ -133,7 +133,6 @@ func main() {
 	resolverFlag := flag.String("resolver", "8.8.8.8,2001:4860:4860::8888", "Comma-separated list of addresses of DNS resolver to use for the test")
 	protoFlag := flag.String("proto", "tcp,udp", "Comma-separated list of the protocols to test. Must be \"tcp\", \"udp\", or a combination of them")
 	reportToFlag := flag.String("report-to", "", "URL to send JSON error reports to")
-	portFlag := flag.String("port", "53", "Resolver port to use for the test")
 	reportSuccessFlag := flag.Float64("report-success-rate", 0.1, "Report success to collector with this probability - must be between 0 and 1")
 	reportFailureFlag := flag.Float64("report-failure-rate", 1, "Report failure to collector with this probability - must be between 0 and 1")
 
@@ -168,7 +167,7 @@ func main() {
 	jsonEncoder.SetEscapeHTML(false)
 	for _, resolverHost := range strings.Split(*resolverFlag, ",") {
 		resolverHost := strings.TrimSpace(resolverHost)
-		resolverAddress := net.JoinHostPort(resolverHost, *portFlag)
+		resolverAddress := net.JoinHostPort(resolverHost, "53")
 		for _, proto := range strings.Split(*protoFlag, ",") {
 			proto = strings.TrimSpace(proto)
 


### PR DESCRIPTION
I made a new branch for this since I messed up the previous branch when doing unnecessary rebase and addressing merge conflicts :( 

I moved all the changes to this branch and also implement failure and success sample rate flags to send reports with a given probability. I also added an optional port flag. There should not be any merge conflict with merge since I fetched upstream before making this branch.

I am going to close the other pull request. 