### PR TITLE
Add 5s timeout to http.Client

### DIFF
--- a/x/examples/fetch/main.go
+++ b/x/examples/fetch/main.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/x/config"
 )
@@ -65,7 +66,7 @@ func main() {
 		}
 		return dialer.Dial(ctx, addr)
 	}
-	httpClient := &http.Client{Transport: &http.Transport{DialContext: dialContext}}
+	httpClient := &http.Client{Transport: &http.Transport{DialContext: dialContext}, Timeout: 5 * time.Second}
 
 	resp, err := httpClient.Get(url)
 	if err != nil {


### PR DESCRIPTION
The GET requests would stuck for a long time if the connections are being interrupted/blocked.