### PR TITLE
Refactoring Outline Connectivity example using report package

### DIFF
--- a/x/report/report.go
+++ b/x/report/report.go
@@ -52,8 +52,8 @@ type Collector interface {
 
 // RemoteCollector represents a collector that communicates with a remote endpoint.
 type RemoteCollector struct {
-	httpClient        *http.Client
-	collectorEndpoint *url.URL
+	HttpClient        *http.Client
+	CollectorEndpoint *url.URL
 }
 
 // Collect sends the given report to the remote collector.
@@ -74,9 +74,9 @@ func (c *RemoteCollector) Collect(ctx context.Context, report Report) error {
 
 // SamplingCollector represents a collector that randomly samples and collects a report.
 type SamplingCollector struct {
-	collector       Collector
-	successFraction float64
-	failureFraction float64
+	Collector       Collector
+	SuccessFraction float64
+	FailureFraction float64
 }
 
 // Collect collects the given report based on the sampling rate defined in the [SamplingCollector].
@@ -92,14 +92,14 @@ func (c *SamplingCollector) Collect(ctx context.Context, report Report) error {
 		return nil
 	}
 	if hs.IsSuccess() {
-		samplingRate = c.successFraction
+		samplingRate = c.SuccessFraction
 	} else {
-		samplingRate = c.failureFraction
+		samplingRate = c.FailureFraction
 	}
 	// Generate a random float64 number between 0 and 1
 	random := rand.Float64()
 	if random < samplingRate {
-		err := c.collector.Collect(ctx, report)
+		err := c.Collector.Collect(ctx, report)
 		if err != nil {
 			return err
 		}
@@ -111,9 +111,9 @@ func (c *SamplingCollector) Collect(ctx context.Context, report Report) error {
 
 // RetryCollector represents a collector that supports retrying failed operations.
 type RetryCollector struct {
-	collector    Collector
-	maxRetry     int
-	initialDelay time.Duration
+	Collector    Collector
+	MaxRetry     int
+	InitialDelay time.Duration
 }
 
 // Collect collects the report by making multiple attempts with retries.
@@ -123,13 +123,13 @@ type RetryCollector struct {
 // Returns an error if the maximum number of retries is exceeded.
 func (c *RetryCollector) Collect(ctx context.Context, report Report) error {
 	var e *BadRequestError
-	for i := 0; i < c.maxRetry; i++ {
-		err := c.collector.Collect(ctx, report)
+	for i := 0; i < c.MaxRetry; i++ {
+		err := c.Collector.Collect(ctx, report)
 		if err != nil {
 			if errors.As(err, &e) {
 				break
 			} else {
-				time.Sleep(time.Duration(math.Pow(2, float64(i))) * c.initialDelay)
+				time.Sleep(time.Duration(math.Pow(2, float64(i))) * c.InitialDelay)
 			}
 		} else {
 			return nil
@@ -140,7 +140,7 @@ func (c *RetryCollector) Collect(ctx context.Context, report Report) error {
 
 // FallbackCollector is a type that represents a collector that falls back to multiple collectors.
 type FallbackCollector struct {
-	collectors []Collector
+	Collectors []Collector
 }
 
 // Collect implements [Collector] interface on [FallbackCollector] type that collects a report using the provided context and report data.
@@ -148,8 +148,8 @@ type FallbackCollector struct {
 // If any of the collectors succeeds in collecting the report, operation aborts, and it returns nil.
 // If all collectors fail to collect the report, it returns an error indicating the failure.
 func (c *FallbackCollector) Collect(ctx context.Context, report Report) error {
-	for i := range c.collectors {
-		err := c.collectors[i].Collect(ctx, report)
+	for i := range c.Collectors {
+		err := c.Collectors[i].Collect(ctx, report)
 		if err == nil {
 			return nil
 		}
@@ -163,13 +163,13 @@ func (c *FallbackCollector) Collect(ctx context.Context, report Report) error {
 // It returns an error if there was a problem sending the report or reading the response.
 func (c *RemoteCollector) sendReport(ctx context.Context, jsonData []byte) error {
 	// TODO: return status code of HTTP response
-	req, err := http.NewRequest("POST", c.collectorEndpoint.String(), bytes.NewReader(jsonData))
+	req, err := http.NewRequest("POST", c.CollectorEndpoint.String(), bytes.NewReader(jsonData))
 	if err != nil {
 		return err
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	resp, err := c.httpClient.Do(req.WithContext(ctx))
+	resp, err := c.HttpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func (c *RemoteCollector) sendReport(ctx context.Context, jsonData []byte) error
 
 // WriteCollector represents a collector that writes the report to an io.Writer.
 type WriteCollector struct {
-	writer io.Writer
+	Writer io.Writer
 }
 
 // Collect writes the report to the underlying io.Writer.
@@ -198,7 +198,7 @@ func (c *WriteCollector) Collect(ctx context.Context, report Report) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
-	_, err = c.writer.Write(jsonData)
+	_, err = c.Writer.Write(jsonData)
 	if err != nil {
 		return err
 	}

--- a/x/report/report_test.go
+++ b/x/report/report_test.go
@@ -110,8 +110,8 @@ func TestSendReportSuccessfully(t *testing.T) {
 		t.Errorf("Expected no error, but got: %v", err)
 	}
 	c := RemoteCollector{
-		collectorEndpoint: u,
-		httpClient:        &http.Client{Timeout: 10 * time.Second},
+		CollectorEndpoint: u,
+		HttpClient:        &http.Client{Timeout: 10 * time.Second},
 	}
 	err = c.Collect(context.Background(), r)
 	if err != nil {
@@ -136,8 +136,8 @@ func TestSendReportUnsuccessfully(t *testing.T) {
 		t.Errorf("Expected no error, but got: %v", err)
 	}
 	c := RemoteCollector{
-		collectorEndpoint: u,
-		httpClient:        &http.Client{Timeout: 10 * time.Second},
+		CollectorEndpoint: u,
+		HttpClient:        &http.Client{Timeout: 10 * time.Second},
 	}
 	err = c.Collect(context.Background(), r)
 	if err == nil {
@@ -167,12 +167,12 @@ func TestSamplingCollector(t *testing.T) {
 		t.Errorf("Expected no error, but got: %v", err)
 	}
 	c := SamplingCollector{
-		collector: &RemoteCollector{
-			collectorEndpoint: u,
-			httpClient:        &http.Client{Timeout: 10 * time.Second},
+		Collector: &RemoteCollector{
+			CollectorEndpoint: u,
+			HttpClient:        &http.Client{Timeout: 10 * time.Second},
 		},
-		successFraction: 0.5,
-		failureFraction: 0.1,
+		SuccessFraction: 0.5,
+		FailureFraction: 0.1,
 	}
 	err = c.Collect(context.Background(), r)
 	if err != nil {
@@ -211,8 +211,8 @@ func TestSendJSONToServer(t *testing.T) {
 	}
 	var r Report = testReport
 	c := RemoteCollector{
-		collectorEndpoint: u,
-		httpClient:        &http.Client{Timeout: 10 * time.Second},
+		CollectorEndpoint: u,
+		HttpClient:        &http.Client{Timeout: 10 * time.Second},
 	}
 	err = c.Collect(context.Background(), r)
 	if err != nil {
@@ -240,14 +240,14 @@ func TestFallbackCollector(t *testing.T) {
 		t.Errorf("Expected no error, but got: %v", err)
 	}
 	c := FallbackCollector{
-		collectors: []Collector{
+		Collectors: []Collector{
 			&RemoteCollector{
-				collectorEndpoint: u1,
-				httpClient:        &http.Client{Timeout: 10 * time.Second},
+				CollectorEndpoint: u1,
+				HttpClient:        &http.Client{Timeout: 10 * time.Second},
 			},
 			&RemoteCollector{
-				collectorEndpoint: u2,
-				httpClient:        &http.Client{Timeout: 10 * time.Second},
+				CollectorEndpoint: u2,
+				HttpClient:        &http.Client{Timeout: 10 * time.Second},
 			},
 		},
 	}
@@ -273,12 +273,12 @@ func TestRetryCollector(t *testing.T) {
 		t.Errorf("Expected no error, but got: %v", err)
 	}
 	c := RetryCollector{
-		collector: &RemoteCollector{
-			collectorEndpoint: u,
-			httpClient:        &http.Client{Timeout: 10 * time.Second},
+		Collector: &RemoteCollector{
+			CollectorEndpoint: u,
+			HttpClient:        &http.Client{Timeout: 10 * time.Second},
 		},
-		maxRetry:     3,
-		initialDelay: 1 * time.Second,
+		MaxRetry:     3,
+		InitialDelay: 1 * time.Second,
 	}
 	err = c.Collect(context.Background(), r)
 	if err == nil {
@@ -300,7 +300,7 @@ func TestWriteCollector(t *testing.T) {
 		fmt.Printf("The test report shows success: %v\n", v.IsSuccess())
 	}
 	c := WriteCollector{
-		writer: io.Discard,
+		Writer: io.Discard,
 	}
 	err := c.Collect(context.Background(), r)
 	if err != nil {
@@ -326,7 +326,7 @@ func TestWriteCollectorToFile(t *testing.T) {
 	}
 	defer os.Remove(f.Name()) // clean up
 	c := WriteCollector{
-		writer: f,
+		Writer: f,
 	}
 	err = c.Collect(context.Background(), r)
 	if err != nil {


### PR DESCRIPTION
 - Outline Connectivity is now using report package to collect connectivity report
 - This PR fixes an issue with report package where Collector type struct fields could not be exported and used externally 