### PR TITLE
Sanitize transport config by embedding of transport.StreamDialer & PacketDialer types

### DIFF
--- a/x/config/config.go
+++ b/x/config/config.go
@@ -68,7 +68,18 @@ func WrapStreamDialer(dialer transport.StreamDialer, transportConfig string) (tr
 	return dialer, nil
 }
 
-func newStreamDialerFromPart(innerDialer transport.StreamDialer, oneDialerConfig string) (transport.StreamDialer, error) {
+
+
+type StreamDialer struct {
+	transport.StreamDialer
+	config string
+}
+
+func (sd *streamDialer) SanitizedConfig() string {
+	return sd.config
+}
+
+func newStreamDialerFromPart(innerDialer *StreamDialer, oneDialerConfig string) (*StreamDialer, error) {
 	url, err := parseConfigPart(oneDialerConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config part: %w", err)
@@ -78,7 +89,7 @@ func newStreamDialerFromPart(innerDialer transport.StreamDialer, oneDialerConfig
 	switch strings.ToLower(url.Scheme) {
 	case "socks5":
 		endpoint := transport.StreamDialerEndpoint{Dialer: innerDialer, Address: url.Host}
-		return socks5.NewStreamDialer(&endpoint)
+		return &streamDialer{StreamDialer: socks5.NewStreamDialer(&endpoint); config: innerDialer.SanitizedConfig() + "|" + oneDialerConfig}
 
 	case "split":
 		prefixBytesStr := url.Opaque

--- a/x/config/config.go
+++ b/x/config/config.go
@@ -124,8 +124,7 @@ func newStreamDialerFromPart(innerDialer transport.StreamDialer, oneDialerConfig
 	}
 
 	// Please keep scheme list sorted.
-	scheme := strings.ToLower(url.Scheme)
-	switch scheme {
+	switch strings.ToLower(url.Scheme) {
 	case "socks5":
 		endpoint := transport.StreamDialerEndpoint{Dialer: innerDialer, Address: url.Host}
 		return socks5.NewStreamDialer(&endpoint)

--- a/x/examples/test-connectivity/main.go
+++ b/x/examples/test-connectivity/main.go
@@ -158,7 +158,7 @@ func main() {
 	// - Server IPv6 dial support
 
 	success := false
-	var transportConfig string
+	var sanitizedConfig string
 	jsonEncoder := json.NewEncoder(os.Stdout)
 	jsonEncoder.SetEscapeHTML(false)
 	for _, resolverHost := range strings.Split(*resolverFlag, ",") {
@@ -170,14 +170,14 @@ func main() {
 			switch proto {
 			case "tcp":
 				streamDialer, err := config.NewStreamDialer(*transportFlag)
-				transportConfig = streamDialer.Config
+				sanitizedConfig = streamDialer.SanitizedConfig
 				if err != nil {
 					log.Fatalf("Failed to create StreamDialer: %v", err)
 				}
 				resolver = connectivity.NewTCPResolver(streamDialer, resolverAddress)
 			case "udp":
 				packetDialer, err := config.NewPacketDialer(*transportFlag)
-				transportConfig = ""
+				sanitizedConfig = packetDialer.SanitizedConfig
 				if err != nil {
 					log.Fatalf("Failed to create PacketDialer: %v", err)
 				}
@@ -200,7 +200,7 @@ func main() {
 				Proto:    proto,
 				Time:     startTime.UTC().Truncate(time.Second),
 				// TODO(fortuna): Add sanitized config:
-				Transport:  transportConfig,
+				Transport:  sanitizedConfig,
 				DurationMs: testDuration.Milliseconds(),
 				Error:      makeErrorRecord(result),
 			}

--- a/x/examples/test-connectivity/main.go
+++ b/x/examples/test-connectivity/main.go
@@ -41,9 +41,8 @@ var debugLog log.Logger = *log.New(io.Discard, "", 0)
 
 type connectivityReport struct {
 	// Inputs
-	Resolver string `json:"resolver"`
-	Proto    string `json:"proto"`
-	// TODO(fortuna): add sanitized transport config.
+	Resolver  string `json:"resolver"`
+	Proto     string `json:"proto"`
 	Transport string `json:"transport"`
 
 	// Observations
@@ -196,10 +195,9 @@ func main() {
 			}
 			debugLog.Printf("Test %v %v result: %v", proto, resolverAddress, result)
 			var r report.Report = connectivityReport{
-				Resolver: resolverAddress,
-				Proto:    proto,
-				Time:     startTime.UTC().Truncate(time.Second),
-				// TODO(fortuna): Add sanitized config:
+				Resolver:   resolverAddress,
+				Proto:      proto,
+				Time:       startTime.UTC().Truncate(time.Second),
 				Transport:  sanitizedConfig,
 				DurationMs: testDuration.Milliseconds(),
 				Error:      makeErrorRecord(result),

--- a/x/examples/test-connectivity/main.go
+++ b/x/examples/test-connectivity/main.go
@@ -44,7 +44,7 @@ type connectivityReport struct {
 	Resolver string `json:"resolver"`
 	Proto    string `json:"proto"`
 	// TODO(fortuna): add sanitized transport config.
-	// Transport    string `json:"transport"`
+	Transport string `json:"transport"`
 
 	// Observations
 	Time       time.Time  `json:"time"`
@@ -158,6 +158,7 @@ func main() {
 	// - Server IPv6 dial support
 
 	success := false
+	var transportConfig string
 	jsonEncoder := json.NewEncoder(os.Stdout)
 	jsonEncoder.SetEscapeHTML(false)
 	for _, resolverHost := range strings.Split(*resolverFlag, ",") {
@@ -169,12 +170,14 @@ func main() {
 			switch proto {
 			case "tcp":
 				streamDialer, err := config.NewStreamDialer(*transportFlag)
+				transportConfig = streamDialer.Config
 				if err != nil {
 					log.Fatalf("Failed to create StreamDialer: %v", err)
 				}
 				resolver = connectivity.NewTCPResolver(streamDialer, resolverAddress)
 			case "udp":
 				packetDialer, err := config.NewPacketDialer(*transportFlag)
+				transportConfig = ""
 				if err != nil {
 					log.Fatalf("Failed to create PacketDialer: %v", err)
 				}
@@ -197,7 +200,7 @@ func main() {
 				Proto:    proto,
 				Time:     startTime.UTC().Truncate(time.Second),
 				// TODO(fortuna): Add sanitized config:
-				// Transport:   config.SanitizedConfig(*transportFlag),
+				Transport:  transportConfig,
 				DurationMs: testDuration.Milliseconds(),
 				Error:      makeErrorRecord(result),
 			}

--- a/x/httpproxy/connect_handler.go
+++ b/x/httpproxy/connect_handler.go
@@ -76,7 +76,8 @@ func (h *connectHandler) ServeHTTP(proxyResp http.ResponseWriter, proxyReq *http
 
 	// Dial the target.
 	transportConfig := proxyReq.Header.Get("Transport")
-	dialer, err := config.WrapStreamDialer(h.dialer, transportConfig)
+
+	dialer, err := config.WrapStreamDialer(&config.StreamDialer{StreamDialer: h.dialer, Config: ""}, transportConfig)
 	if err != nil {
 		// Because we sanitize the base dialer error, it's safe to return error details here.
 		http.Error(proxyResp, fmt.Sprintf("Invalid config in Transport header: %v", err), http.StatusBadRequest)

--- a/x/httpproxy/connect_handler.go
+++ b/x/httpproxy/connect_handler.go
@@ -77,7 +77,7 @@ func (h *connectHandler) ServeHTTP(proxyResp http.ResponseWriter, proxyReq *http
 	// Dial the target.
 	transportConfig := proxyReq.Header.Get("Transport")
 
-	dialer, err := config.WrapStreamDialer(&config.StreamDialer{StreamDialer: h.dialer, Config: ""}, transportConfig)
+	dialer, err := config.WrapStreamDialer(&config.StreamDialer{StreamDialer: h.dialer, SanitizedConfig: ""}, transportConfig)
 	if err != nil {
 		// Because we sanitize the base dialer error, it's safe to return error details here.
 		http.Error(proxyResp, fmt.Sprintf("Invalid config in Transport header: %v", err), http.StatusBadRequest)


### PR DESCRIPTION
This PR proposes using embedding of `transport.StreamDialer` & `transport.PacketDialer` types with `SanitizedConfig` string that holds the sanitized config for the wrapped dialer. 