### PR TITLE
fix: fix CONNECT handler stalemate

### DIFF
--- a/transport/stream.go
+++ b/transport/stream.go
@@ -52,6 +52,10 @@ func (dc *duplexConnAdaptor) Write(b []byte) (int, error) {
 	return dc.w.Write(b)
 }
 func (dc *duplexConnAdaptor) ReadFrom(r io.Reader) (int64, error) {
+	// Make sure we prefer ReadFrom. Otherwise io.Copy will try WriteTo first.
+	if rf, ok := r.(io.ReaderFrom); ok {
+		return rf.ReadFrom(r)
+	}
 	return io.Copy(dc.w, r)
 }
 func (dc *duplexConnAdaptor) CloseWrite() error {

--- a/x/httpproxy/connect_handler.go
+++ b/x/httpproxy/connect_handler.go
@@ -119,7 +119,10 @@ func (h *connectHandler) ServeHTTP(proxyResp http.ResponseWriter, proxyReq *http
 		io.Copy(targetConn, clientRW)
 		targetConn.CloseWrite()
 	}()
-	io.Copy(clientRW, targetConn)
+	// We can't use io.Copy here because it doesn't call Flush on writes, so the first
+	// write is never sent and the entire relay gets stuck. bufio.Writer.ReadFrom takes
+	// care of that.
+	clientRW.ReadFrom(targetConn)
 	clientRW.Flush()
 }
 


### PR DESCRIPTION
Fixes https://github.com/Jigsaw-Code/outline-sdk/issues/210

I also improve the conn adaptor ReadFrom to prefer the inner ReadFrom when possible. It's easier to reason about and shortcuts some nesting.