### PR TITLE
WIP: Draft PR for improving connectivity testing to capture revolved IPs and all attempts 

### DIFF
--- a/x/config/config.go
+++ b/x/config/config.go
@@ -47,7 +47,7 @@ func NewStreamDialer(transportConfig string) (transport.StreamDialer, error) {
 	return WrapStreamDialer(&transport.TCPDialer{}, transportConfig)
 }
 
-// WrapStreamDialer created a [transport.StreamDialer] according to transportConfig, using dialer as the
+// WrapStreamDialer creates a [transport.StreamDialer] according to transportConfig, using dialer as the
 // base [transport.StreamDialer]. The given dialer must not be nil.
 func WrapStreamDialer(dialer transport.StreamDialer, transportConfig string) (transport.StreamDialer, error) {
 	if dialer == nil {
@@ -110,11 +110,17 @@ func newStreamDialerFromPart(innerDialer transport.StreamDialer, oneDialerConfig
 
 // NewPacketDialer creates a new [transport.PacketDialer] according to the given config.
 func NewPacketDialer(transportConfig string) (dialer transport.PacketDialer, err error) {
-	dialer = &transport.UDPDialer{}
+	return WrapPacketDialer(&transport.UDPDialer{}, transportConfig)
+}
+
+// WrapPacketDialer creates a [transport.PacketDialer] according to transportConfig, using dialer as the
+// base [transport.PacketDialer]. The given dialer must not be nil.
+func WrapPacketDialer(dialer transport.PacketDialer, transportConfig string) (transport.PacketDialer, error) {
 	transportConfig = strings.TrimSpace(transportConfig)
 	if transportConfig == "" {
 		return dialer, nil
 	}
+	var err error
 	for _, part := range strings.Split(transportConfig, "|") {
 		dialer, err = newPacketDialerFromPart(dialer, part)
 		if err != nil {

--- a/x/connectivity/connectivity.go
+++ b/x/connectivity/connectivity.go
@@ -78,6 +78,7 @@ type WrapStreamDialer func(baseDialer transport.StreamDialer) (transport.StreamD
 
 // TestStreamConnectivityWithDNS tests weather we can get a response from a DNS resolver at resolverAddress over a stream connection. It sends testDomain as the query.
 // It uses the baseDialer to create a first-hop connection to the proxy, and the wrap to apply the transport.
+// The baseDialer is typically TCPDialer, but it can be replaced for remote measurements.
 func TestStreamConnectivityWithDNS(ctx context.Context, baseDialer transport.StreamDialer, wrap WrapStreamDialer, resolverAddress string, testDomain string) (*ConnectivityResult, error) {
 	result := &ConnectivityResult{}
 	interceptDialer := transport.FuncStreamDialer(func(ctx context.Context, addr string) (transport.StreamConn, error) {
@@ -103,6 +104,7 @@ type WrapPacketDialer func(baseDialer transport.PacketDialer) (transport.PacketD
 
 // TestPacketConnectivityWithDNS tests weather we can get a response from a DNS resolver at resolverAddress over a packet connection. It sends testDomain as the query.
 // It uses the baseDialer to create a first-hop connection to the proxy, and the wrap to apply the transport.
+// The baseDialer is typically UDPDialer, but it can be replaced for remote measurements.
 func TestPacketConnectivityWithDNS(ctx context.Context, baseDialer transport.PacketDialer, wrap WrapPacketDialer, resolverAddress string, testDomain string) (*ConnectivityResult, error) {
 	result := &ConnectivityResult{}
 	interceptDialer := transport.FuncPacketDialer(func(ctx context.Context, addr string) (net.Conn, error) {

--- a/x/connectivity/connectivity.go
+++ b/x/connectivity/connectivity.go
@@ -102,7 +102,7 @@ func TestStreamConnectivityWithDNS(ctx context.Context, baseDialer transport.Str
 		for _, ip := range ips {
 			addr := net.JoinHostPort(ip, port)
 			connResult := ConnectionResult{Address: addr}
-			deadline := time.Now().Add(1 * time.Second)
+			deadline := time.Now().Add(5 * time.Second)
 			ipCtx, cancel := context.WithDeadline(ctx, deadline)
 			defer cancel()
 			conn, err = baseDialer.DialStream(ipCtx, addr)

--- a/x/connectivity/connectivity.go
+++ b/x/connectivity/connectivity.go
@@ -29,19 +29,28 @@ import (
 
 // ConnectivityResult captures the observed result of the connectivity test.
 type ConnectivityResult struct {
-	// Address we connected to
-	Connections []ConnectionResult
+	// The result of the initial connect attempt
+	Connect ConnectResult
 	// Address of the connection that was selected
 	SelectedAddress string
 	// Observed error
 	Error *ConnectivityError
 }
 
-type ConnectionResult struct {
-	// Address we connected to
-	Address string
+type ConnectResult struct {
+	// Address we dialed
+	DialedAddress string
+	// Address we selected
+	SelectedAddress string
+	// Lists each connection attempt
+	Attempts []ConnectionAttempt
 	// Observed error
 	Error *ConnectivityError
+}
+
+type ConnectionAttempt struct {
+	Address string
+	Error   error
 }
 
 // ConnectivityError captures the observed error of the connectivity test.
@@ -89,10 +98,12 @@ type WrapStreamDialer func(baseDialer transport.StreamDialer) (transport.StreamD
 // It uses the baseDialer to create a first-hop connection to the proxy, and the wrap to apply the transport.
 // The baseDialer is typically TCPDialer, but it can be replaced for remote measurements.
 func TestStreamConnectivityWithDNS(ctx context.Context, baseDialer transport.StreamDialer, wrap WrapStreamDialer, resolverAddress string, testDomain string) (*ConnectivityResult, error) {
-	testResult := &ConnectivityResult{
-		Connections: make([]ConnectionResult, 0),
-	}
+	testResult := &ConnectivityResult{}
 	interceptDialer := transport.FuncStreamDialer(func(ctx context.Context, addr string) (transport.StreamConn, error) {
+		connectResult := &testResult.Connect
+		// Captures the address of the first hop, before resolution.
+		connectResult.DialedAddress = addr
+		connectResult.Attempts = make([]ConnectionAttempt, 0)
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
 			return nil, err
@@ -101,17 +112,18 @@ func TestStreamConnectivityWithDNS(ctx context.Context, baseDialer transport.Str
 		var conn transport.StreamConn
 		for _, ip := range ips {
 			addr := net.JoinHostPort(ip, port)
-			connResult := ConnectionResult{Address: addr}
+			attemptResult := ConnectionAttempt{Address: addr}
+			// TODO: This is slow. Race and overlap attempts instead.
 			deadline := time.Now().Add(5 * time.Second)
 			ipCtx, cancel := context.WithDeadline(ctx, deadline)
 			defer cancel()
 			conn, err = baseDialer.DialStream(ipCtx, addr)
 			if err != nil {
-				connResult.Error = makeConnectivityError("connect", err)
+				attemptResult.Error = err
 			}
-			testResult.Connections = append(testResult.Connections, connResult)
+			connectResult.Attempts = append(connectResult.Attempts, attemptResult)
 			if err == nil {
-				testResult.SelectedAddress = addr
+				connectResult.SelectedAddress = addr
 				break
 			}
 		}

--- a/x/examples/test-connectivity/main.go
+++ b/x/examples/test-connectivity/main.go
@@ -187,12 +187,12 @@ func main() {
 			startTime := time.Now()
 			switch proto {
 			case "tcp":
-				wrap := func(ctx context.Context, baseDialer transport.StreamDialer) (transport.StreamDialer, error) {
+				wrap := func(baseDialer transport.StreamDialer) (transport.StreamDialer, error) {
 					return config.WrapStreamDialer(baseDialer, *transportFlag)
 				}
 				testResult, testErr = connectivity.TestStreamConnectivityWithDNS(context.Background(), &transport.TCPDialer{}, wrap, resolverAddress, *domainFlag)
 			case "udp":
-				wrap := func(ctx context.Context, baseDialer transport.PacketDialer) (transport.PacketDialer, error) {
+				wrap := func(baseDialer transport.PacketDialer) (transport.PacketDialer, error) {
 					return config.WrapPacketDialer(baseDialer, *transportFlag)
 				}
 				testResult, testErr = connectivity.TestPacketConnectivityWithDNS(context.Background(), &transport.UDPDialer{}, wrap, resolverAddress, *domainFlag)

--- a/x/examples/test-connectivity/main.go
+++ b/x/examples/test-connectivity/main.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Jigsaw-Code/outline-sdk/dns"
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/Jigsaw-Code/outline-sdk/x/config"
 	"github.com/Jigsaw-Code/outline-sdk/x/connectivity"
@@ -183,48 +182,33 @@ func main() {
 		resolverAddress := net.JoinHostPort(resolverHost, "53")
 		for _, proto := range strings.Split(*protoFlag, ",") {
 			proto = strings.TrimSpace(proto)
-			var resolver dns.Resolver
-			var connectionAddress string
+			var testResult *connectivity.ConnectivityResult
+			var testErr error
+			startTime := time.Now()
 			switch proto {
 			case "tcp":
-				baseDialer := transport.FuncStreamDialer(func(ctx context.Context, addr string) (transport.StreamConn, error) {
-					conn, err := (&transport.TCPDialer{}).DialStream(ctx, addr)
-					if conn != nil {
-						connectionAddress = conn.RemoteAddr().String()
-					}
-					return conn, err
-				})
-				streamDialer, err := config.WrapStreamDialer(baseDialer, *transportFlag)
+				dialer, err := config.WrapStreamDialer(&transport.TCPDialer{}, *transportFlag)
 				if err != nil {
 					log.Fatalf("Failed to create StreamDialer: %v", err)
 				}
-				resolver = dns.NewTCPResolver(streamDialer, resolverAddress)
+				testResult, testErr = connectivity.TestStreamConnectivityWithDNS(context.Background(), dialer, resolverAddress, *domainFlag)
 			case "udp":
-				baseDialer := transport.FuncPacketDialer(func(ctx context.Context, addr string) (net.Conn, error) {
-					conn, err := (&transport.UDPDialer{}).DialPacket(ctx, addr)
-					if conn != nil {
-						connectionAddress = conn.RemoteAddr().String()
-					}
-					return conn, err
-				})
-				packetDialer, err := config.WrapPacketDialer(baseDialer, *transportFlag)
+				dialer, err := config.WrapPacketDialer(&transport.UDPDialer{}, *transportFlag)
 				if err != nil {
 					log.Fatalf("Failed to create PacketDialer: %v", err)
 				}
-				resolver = dns.NewUDPResolver(packetDialer, resolverAddress)
+				testResult, testErr = connectivity.TestPacketConnectivityWithDNS(context.Background(), dialer, resolverAddress, *domainFlag)
 			default:
 				log.Fatalf(`Invalid proto %v. Must be "tcp" or "udp"`, proto)
 			}
-			startTime := time.Now()
-			result, err := connectivity.TestConnectivityWithResolver(context.Background(), resolver, *domainFlag)
-			if err != nil {
-				log.Fatalf("Connectivity test failed to run: %v", err)
+			if testErr != nil {
+				log.Fatalf("Connectivity test failed to run: %v", testErr)
 			}
 			testDuration := time.Since(startTime)
-			if result == nil {
+			if testResult.Error == nil {
 				success = true
 			}
-			debugLog.Printf("Test %v %v result: %v", proto, resolverAddress, result)
+			debugLog.Printf("Test %v %v result: %v", proto, resolverAddress, testResult)
 			sanitizedConfig, err := config.SanitizeConfig(*transportFlag)
 			if err != nil {
 				log.Fatalf("Failed to sanitize config: %v", err)
@@ -236,9 +220,9 @@ func main() {
 				// TODO(fortuna): Add sanitized config:
 				Transport:  sanitizedConfig,
 				DurationMs: testDuration.Milliseconds(),
-				Error:      makeErrorRecord(result),
+				Error:      makeErrorRecord(testResult.Error),
 			}
-			connectionAddressJSON, err := newAddressJSON(connectionAddress)
+			connectionAddressJSON, err := newAddressJSON(testResult.ConnectionAddress)
 			if err == nil {
 				r.ConnectionAddress = connectionAddressJSON
 			}

--- a/x/examples/test-connectivity/main.go
+++ b/x/examples/test-connectivity/main.go
@@ -187,17 +187,15 @@ func main() {
 			startTime := time.Now()
 			switch proto {
 			case "tcp":
-				dialer, err := config.WrapStreamDialer(&transport.TCPDialer{}, *transportFlag)
-				if err != nil {
-					log.Fatalf("Failed to create StreamDialer: %v", err)
+				wrap := func(ctx context.Context, baseDialer transport.StreamDialer) (transport.StreamDialer, error) {
+					return config.WrapStreamDialer(baseDialer, *transportFlag)
 				}
-				testResult, testErr = connectivity.TestStreamConnectivityWithDNS(context.Background(), dialer, resolverAddress, *domainFlag)
+				testResult, testErr = connectivity.TestStreamConnectivityWithDNS(context.Background(), &transport.TCPDialer{}, wrap, resolverAddress, *domainFlag)
 			case "udp":
-				dialer, err := config.WrapPacketDialer(&transport.UDPDialer{}, *transportFlag)
-				if err != nil {
-					log.Fatalf("Failed to create PacketDialer: %v", err)
+				wrap := func(ctx context.Context, baseDialer transport.PacketDialer) (transport.PacketDialer, error) {
+					return config.WrapPacketDialer(baseDialer, *transportFlag)
 				}
-				testResult, testErr = connectivity.TestPacketConnectivityWithDNS(context.Background(), dialer, resolverAddress, *domainFlag)
+				testResult, testErr = connectivity.TestPacketConnectivityWithDNS(context.Background(), &transport.UDPDialer{}, wrap, resolverAddress, *domainFlag)
 			default:
 				log.Fatalf(`Invalid proto %v. Must be "tcp" or "udp"`, proto)
 			}

--- a/x/examples/test-connectivity/main.go
+++ b/x/examples/test-connectivity/main.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/dns"
+	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/Jigsaw-Code/outline-sdk/x/config"
 	"github.com/Jigsaw-Code/outline-sdk/x/connectivity"
 	"github.com/Jigsaw-Code/outline-sdk/x/report"
@@ -47,6 +48,9 @@ type connectivityReport struct {
 	// TODO(fortuna): add sanitized transport config.
 	Transport string `json:"transport"`
 
+	// The address of the selected connection to the proxy server.
+	ConnectionAddress addressJSON `json:"connection_address"`
+
 	// Observations
 	Time       time.Time  `json:"time"`
 	DurationMs int64      `json:"duration_ms"`
@@ -60,6 +64,19 @@ type errorJSON struct {
 	PosixError string `json:"posix_error,omitempty"`
 	// TODO: remove IP addresses
 	Msg string `json:"msg,omitempty"`
+}
+
+type addressJSON struct {
+	Host string `json:"host"`
+	Port string `json:"port"`
+}
+
+func newAddressJSON(address string) (addressJSON, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return addressJSON{}, err
+	}
+	return addressJSON{host, port}, nil
 }
 
 func makeErrorRecord(result *connectivity.ConnectivityError) *errorJSON {
@@ -167,15 +184,30 @@ func main() {
 		for _, proto := range strings.Split(*protoFlag, ",") {
 			proto = strings.TrimSpace(proto)
 			var resolver dns.Resolver
+			var connectionAddress string
 			switch proto {
 			case "tcp":
-				streamDialer, err := config.NewStreamDialer(*transportFlag)
+				baseDialer := transport.FuncStreamDialer(func(ctx context.Context, addr string) (transport.StreamConn, error) {
+					conn, err := (&transport.TCPDialer{}).DialStream(ctx, addr)
+					if conn != nil {
+						connectionAddress = conn.RemoteAddr().String()
+					}
+					return conn, err
+				})
+				streamDialer, err := config.WrapStreamDialer(baseDialer, *transportFlag)
 				if err != nil {
 					log.Fatalf("Failed to create StreamDialer: %v", err)
 				}
 				resolver = dns.NewTCPResolver(streamDialer, resolverAddress)
 			case "udp":
-				packetDialer, err := config.NewPacketDialer(*transportFlag)
+				baseDialer := transport.FuncPacketDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+					conn, err := (&transport.UDPDialer{}).DialPacket(ctx, addr)
+					if conn != nil {
+						connectionAddress = conn.RemoteAddr().String()
+					}
+					return conn, err
+				})
+				packetDialer, err := config.WrapPacketDialer(baseDialer, *transportFlag)
 				if err != nil {
 					log.Fatalf("Failed to create PacketDialer: %v", err)
 				}
@@ -197,7 +229,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("Failed to sanitize config: %v", err)
 			}
-			var r report.Report = connectivityReport{
+			r := connectivityReport{
 				Resolver: resolverAddress,
 				Proto:    proto,
 				Time:     startTime.UTC().Truncate(time.Second),
@@ -206,6 +238,11 @@ func main() {
 				DurationMs: testDuration.Milliseconds(),
 				Error:      makeErrorRecord(result),
 			}
+			connectionAddressJSON, err := newAddressJSON(connectionAddress)
+			if err == nil {
+				r.ConnectionAddress = connectionAddressJSON
+			}
+
 			if reportCollector != nil {
 				err = reportCollector.Collect(context.Background(), r)
 				if err != nil {

--- a/x/examples/test-connectivity/main.go
+++ b/x/examples/test-connectivity/main.go
@@ -47,14 +47,19 @@ type connectivityReport struct {
 	// TODO(fortuna): add sanitized transport config.
 	Transport string `json:"transport"`
 
-	// The address of the selected connection to the proxy server.
-	Connections     []connectionJSON `json:"connections"`
-	SelectedAddress *addressJSON     `json:"selected_address,omitempty"`
+	// The result for the connection.
+	Connect         connectAttemptJSON `json:"connect"`
+	SelectedAddress *addressJSON       `json:"selected_address,omitempty"`
 
 	// Observations
 	Time       time.Time  `json:"time"`
 	DurationMs int64      `json:"duration_ms"`
 	Error      *errorJSON `json:"error"`
+}
+
+type connectAttemptJSON struct {
+	Address  *addressJSON         `json:"address,omitempty"`
+	Attempts []connectAttemptJSON `json:"attempts,omitempty"`
 }
 
 type connectionJSON struct {


### PR DESCRIPTION
**Note**: The code is still messy not ready for merge. I made this PR to discuss upcoming high changes to testing approach and format for connectivity testing. 

I moved the `loop` that iterates over ip addresses outside of the intercept dialer. This way in each iteration I am generating a new intercept dialer that takes one of the resolved addresses and use that to continue the end-to-end test.

In this approach, I am allowing each attempt to run end-to-end. The test may fail earlier for example at connect attempt. In that case, it won't continue to the next stage. However each attempt could continue to the end and test for connect/read/write operations for each resolved IP. 

## Format
I am proposing below format that we can use for both `udp` and `tcp`. 

List of suggested format changes:
- Each attempt should include a start-time and duration
- The error captured for each attempt should be a `ConnectivityError` type that includes `op`, `PosixError`, `Error` fields.
- I am uncertain about keeping `selected_address` in the main report. It is hard to tell which address this should be populated with.
- I am uncertain what `error` field in the main report should be populated with. What if the test makes 3 attempts and all of them fail with different types of errors. Does 'error' then reflect? I guess when one of the attempts succeed `error` field should be `nil`. 

TODO: The code is slow and I am planning to optimize it such that tests run in an independent treads in parallel.

```
{
    "resolver": "8.8.8.8:53",
    "proto": "udp",
    "transport": "ss://REDACTED@pod2.exampledomain.com:65496?prefix=",
    "endpoint": {
        "host": "pod2.exampledomain.com",
        "port": "65496"
    },
    "connect": {
        "attempts": [
            {
                "address": {
                    "host": "2606:4700:3032::6815:xxxx",
                    "port": "65496"
                },
                "time": "2024-05-02T05:02:13Z",
                "duration_ms": 1000,
                "error": {
                    "op": "connect",
                    "msg": "i/o timeout"
                }
            },
            {
                "address": {
                    "host": "2606:4700:3032::ac43:xxxx",
                    "port": "65496"
                },
                "time": "2024-05-02T05:02:13Z",
                "duration_ms": 1000,
                "error": {
                    "op": "read",
                    "msg": "reset"
                }
            },
            {
                "address": {
                    "host": "172.67.138.xx",
                    "port": "65496"
                },
                "time": "2024-05-02T05:02:13Z",
                "duration_ms": 1000,
                "error": {
                    "op": "connect",
                    "msg": "i/o timeout"
                }
            },
            {
                "address": {
                    "host": "104.21.38.xx",
                    "port": "65496"
                },
                "time": "2024-05-02T05:02:13Z",
                "duration_ms": 1000,
                "error": {
                    "op": "connect",
                    "msg": "i/o timeout"
                }
            }
        ]
    },
    // maybe we should remove this; what if both IPv4 and IPv6 addresses succeed, 
    // then which one is the selected address?
    "selected_address": { 
        "host": "104.21.38.199",
        "port": "65496"
    },
    // This would be the start-time of the main test and the duration for the whole test
    "time": "2024-05-02T05:02:13Z",
    "duration_ms": 20006,
    // maybe we should remove this one too or make it a summary of all errors in the all attempts. 
    // I am not sure what this field would reflect is we have two failed attempts. I guess this should be `nil`
   // if at least of the tests pass?
    "error": {
        "op": "connect",
        "msg": "all connect attempts failed. no more addresses to try"
    }
}
``` 

