### PR TITLE
fix: duplexConn ReadFrom and connect handler initial data coalescing

### DIFF
--- a/transport/stream.go
+++ b/transport/stream.go
@@ -53,7 +53,7 @@ func (dc *duplexConnAdaptor) Write(b []byte) (int, error) {
 }
 func (dc *duplexConnAdaptor) ReadFrom(r io.Reader) (int64, error) {
 	// Make sure we prefer ReadFrom. Otherwise io.Copy will try WriteTo first.
-	if rf, ok := r.(io.ReaderFrom); ok {
+	if rf, ok := dc.w.(io.ReaderFrom); ok {
 		return rf.ReadFrom(r)
 	}
 	return io.Copy(dc.w, r)

--- a/x/httpproxy/connect_handler.go
+++ b/x/httpproxy/connect_handler.go
@@ -120,7 +120,7 @@ func (h *connectHandler) ServeHTTP(proxyResp http.ResponseWriter, proxyReq *http
 	// Relay data between client and target in both directions.
 	go func() {
 		// io.Copy prefers WriteTo, which clientRW implements. However,
-		// bufio.ReadWriter.ReadFrom issues an empty Write() call, which flushes
+		// bufio.ReadWriter.WriteTo issues an empty Write() call, which flushes
 		// the Shadowsocks IV and connect request, breaking the coalescing with
 		// the initial data. By preferring ReaderFrom, the coalescing of IV,
 		// request and initial data is preserved.

--- a/x/report/report_test.go
+++ b/x/report/report_test.go
@@ -81,43 +81,44 @@ func TestIsSuccess(t *testing.T) {
 	}
 }
 
-func TestSendReportSuccessfully(t *testing.T) {
-	var testSetup = ConnectivitySetup{
-		Proxy:    "testProxy",
-		Resolver: "8.8.8.8",
-		Proto:    "udp",
-		Prefix:   "HTTP1/1",
-	}
-	var testErr = ConnectivityError{
-		Op:         "read",
-		PosixError: "ETIMEDOUT",
-		Msg:        "i/o timeout",
-	}
-	var testReport = ConnectivityReport{
-		Connection: testSetup,
-		Time:       time.Now().UTC().Truncate(time.Second),
-		DurationMs: 1,
-		Error:      testErr,
-	}
+// TODO(fortuna): Make this work without the external service.
+// func TestSendReportSuccessfully(t *testing.T) {
+// 	var testSetup = ConnectivitySetup{
+// 		Proxy:    "testProxy",
+// 		Resolver: "8.8.8.8",
+// 		Proto:    "udp",
+// 		Prefix:   "HTTP1/1",
+// 	}
+// 	var testErr = ConnectivityError{
+// 		Op:         "read",
+// 		PosixError: "ETIMEDOUT",
+// 		Msg:        "i/o timeout",
+// 	}
+// 	var testReport = ConnectivityReport{
+// 		Connection: testSetup,
+// 		Time:       time.Now().UTC().Truncate(time.Second),
+// 		DurationMs: 1,
+// 		Error:      testErr,
+// 	}
 
-	var r Report = testReport
-	v, ok := r.(HasSuccess)
-	if ok {
-		fmt.Printf("The test report shows success: %v\n", v.IsSuccess())
-	}
-	u, err := url.Parse("https://script.google.com/macros/s/AKfycbzoMBmftQaR9Aw4jzTB-w4TwkDjLHtSfBCFhh4_2NhTEZAUdj85Qt8uYCKCNOEAwCg4/exec")
-	if err != nil {
-		t.Errorf("Expected no error, but got: %v", err)
-	}
-	c := RemoteCollector{
-		CollectorURL: u,
-		HttpClient:   &http.Client{Timeout: 10 * time.Second},
-	}
-	err = c.Collect(context.Background(), r)
-	if err != nil {
-		t.Errorf("Expected no error, but got: %v", err)
-	}
-}
+// 	var r Report = testReport
+// 	v, ok := r.(HasSuccess)
+// 	if ok {
+// 		fmt.Printf("The test report shows success: %v\n", v.IsSuccess())
+// 	}
+// 	u, err := url.Parse("https://script.google.com/macros/s/AKfycbzoMBmftQaR9Aw4jzTB-w4TwkDjLHtSfBCFhh4_2NhTEZAUdj85Qt8uYCKCNOEAwCg4/exec")
+// 	if err != nil {
+// 		t.Errorf("Expected no error, but got: %v", err)
+// 	}
+// 	c := RemoteCollector{
+// 		CollectorURL: u,
+// 		HttpClient:   &http.Client{Timeout: 10 * time.Second},
+// 	}
+// 	err = c.Collect(context.Background(), r)
+// 	if err != nil {
+// 		t.Errorf("Expected no error, but got: %v", err)
+// 	}
+// }
 
 func TestSendReportUnsuccessfully(t *testing.T) {
 	var testReport = ConnectivityReport{


### PR DESCRIPTION
I'm also fixing the connect handler, which was not properly coalescing the initial data.

It was that fix that made me realize the issue with the duplexConn.
And I removed a test that was using an external service.