### PR TITLE
fix(test): wrong url used in expired certificate test

### DIFF
--- a/transport/tls/stream_dialer_test.go
+++ b/transport/tls/stream_dialer_test.go
@@ -17,6 +17,7 @@ package tls
 import (
 	"context"
 	"crypto/x509"
+	"runtime"
 	"testing"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
@@ -54,6 +55,11 @@ func TestExpired(t *testing.T) {
 }
 
 func TestRevoked(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("Certificate revocation list is not up-to-date in Linux")
+		return
+	}
+
 	sd, err := NewStreamDialer(&transport.TCPDialer{})
 	require.NoError(t, err)
 	conn, err := sd.DialStream(context.Background(), "revoked.badssl.com:443")

--- a/transport/tls/stream_dialer_test.go
+++ b/transport/tls/stream_dialer_test.go
@@ -44,10 +44,10 @@ func TestUntrustedRoot(t *testing.T) {
 	require.ErrorAs(t, err, &certErr)
 }
 
-func TestRevoked(t *testing.T) {
+func TestExpired(t *testing.T) {
 	sd, err := NewStreamDialer(&transport.TCPDialer{})
 	require.NoError(t, err)
-	_, err = sd.DialStream(context.Background(), "revoked.badssl.com:443")
+	_, err = sd.DialStream(context.Background(), "expired.badssl.com:443")
 	var certErr x509.CertificateInvalidError
 	require.ErrorAs(t, err, &certErr)
 	require.Equal(t, x509.Expired, certErr.Reason)

--- a/transport/tls/stream_dialer_test.go
+++ b/transport/tls/stream_dialer_test.go
@@ -53,6 +53,16 @@ func TestExpired(t *testing.T) {
 	require.Equal(t, x509.Expired, certErr.Reason)
 }
 
+func TestRevoked(t *testing.T) {
+	sd, err := NewStreamDialer(&transport.TCPDialer{})
+	require.NoError(t, err)
+	conn, err := sd.DialStream(context.Background(), "revoked.badssl.com:443")
+
+	// Revocation error is thrown by the system API and is not not strongly typed
+	require.ErrorContains(t, err, "certificate is revoked")
+	require.Nil(t, conn)
+}
+
 func TestIP(t *testing.T) {
 	sd, err := NewStreamDialer(&transport.TCPDialer{})
 	require.NoError(t, err)

--- a/transport/tls/stream_dialer_test.go
+++ b/transport/tls/stream_dialer_test.go
@@ -55,16 +55,15 @@ func TestExpired(t *testing.T) {
 }
 
 func TestRevoked(t *testing.T) {
-	if runtime.GOOS == "linux" {
-		t.Skip("Certificate revocation list is not up-to-date in Linux")
-		return
+	if runtime.GOOS == "linux" || runtime.GOOS == "windows" {
+		t.Skip("Certificate revocation list is not up-to-date in Linux and Windows")
 	}
 
 	sd, err := NewStreamDialer(&transport.TCPDialer{})
 	require.NoError(t, err)
 	conn, err := sd.DialStream(context.Background(), "revoked.badssl.com:443")
 
-	// Revocation error is thrown by the system API and is not not strongly typed
+	// Revocation error is thrown by the system API and is not strongly typed
 	require.ErrorContains(t, err, "certificate is revoked")
 	require.Nil(t, conn)
 }


### PR DESCRIPTION
The `TestRevoked` should be `TestExpired` because the reason `x509.Expired` in `CertificateInvalidError` stands for an expired certificate.

Revoked certificate test is tricky, because it relies on the OS implementation (e.g., [macOS](https://cs.opensource.google/go/go/+/refs/tags/go1.22.3:src/crypto/x509/root_darwin.go;l=71), [Windows](https://cs.opensource.google/go/go/+/master:src/crypto/x509/root_windows.go;l=203)), the error is weakly typed and different OS will report different error messages. For now the revocation test case for Linux and Windows are skipped because the certificate revocation list is not up-to-date on these two platforms.

The failing CI is blocking all PRs including #203, #226, and #241 .