### PR TITLE
WIP/DRAFT: Introducing Trace package and adding trace hooks/callbacks for events

### DIFF
--- a/transport/tls/stream_dialer.go
+++ b/transport/tls/stream_dialer.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
+	"github.com/Jigsaw-Code/outline-sdk/x/trace"
 )
 
 // StreamDialer is a [transport.StreamDialer] that uses TLS to wrap the inner StreamDialer.
@@ -128,13 +129,20 @@ type ClientOption func(serverName string, config *ClientConfig)
 
 // WrapConn wraps a [transport.StreamConn] in a TLS connection.
 func WrapConn(ctx context.Context, conn transport.StreamConn, serverName string, options ...ClientOption) (transport.StreamConn, error) {
+	t := trace.GetTLSClientTrace(ctx)
 	cfg := ClientConfig{ServerName: serverName, CertificateName: serverName}
 	normName := normalizeHost(serverName)
 	for _, option := range options {
 		option(normName, &cfg)
 	}
 	tlsConn := tls.Client(conn, cfg.toStdConfig())
+	if t != nil && t.TLSHandshakeStart != nil {
+		t.TLSHandshakeStart()
+	}
 	err := tlsConn.HandshakeContext(ctx)
+	if t != nil && t.TLSHandshakeDone != nil {
+		t.TLSHandshakeDone(tlsConn.ConnectionState(), err)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/x/config/config.go
+++ b/x/config/config.go
@@ -251,7 +251,7 @@ func SanitizeConfig(transportConfig string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-		case "override", "split", "tls", "tlsfrag":
+		case "override", "split", "tls", "tlsfrag", "do53", "doh", "ws":
 			// No sanitization needed
 			textParts[i] = u.String()
 		default:

--- a/x/connectivity/connectivity.go
+++ b/x/connectivity/connectivity.go
@@ -16,12 +16,22 @@ package connectivity
 
 import (
 	"context"
+	ctls "crypto/tls"
 	"errors"
 	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptrace"
+	"os"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/dns"
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+	"github.com/Jigsaw-Code/outline-sdk/x/trace"
 	"golang.org/x/net/dns/dnsmessage"
 )
 
@@ -83,6 +93,7 @@ func TestConnectivityWithResolver(ctx context.Context, resolver dns.Resolver, te
 		return nil, fmt.Errorf("question creation failed: %w", err)
 	}
 
+	// Pass this context to your DNS resolver function
 	_, err = resolver.Query(ctx, *q)
 
 	if errors.Is(err, dns.ErrBadRequest) {
@@ -96,4 +107,181 @@ func TestConnectivityWithResolver(ctx context.Context, resolver dns.Resolver, te
 		return makeConnectivityError("receive", err), nil
 	}
 	return nil, nil
+}
+
+func TestStreamConnectivitywithHTTP(ctx context.Context, baseDialer transport.StreamDialer, domain string, timeout time.Duration, method string) (*ConnectivityError, error) {
+	dialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid address: %w", err)
+		}
+		if !strings.HasPrefix(network, "tcp") {
+			return nil, fmt.Errorf("protocol not supported: %v", network)
+		}
+		return baseDialer.DialStream(ctx, net.JoinHostPort(host, port))
+	}
+	httpClient := &http.Client{
+		Transport: &http.Transport{DialContext: dialContext},
+		Timeout:   time.Duration(timeout) * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	req, err := http.NewRequest(method, domain, nil)
+	if err != nil {
+		log.Fatalln("Failed to create request:", err)
+	}
+	// TODO: Add this as test param
+	// headerText := strings.Join(headersFlag, "\r\n") + "\r\n\r\n"
+	// h, err := textproto.NewReader(bufio.NewReader(strings.NewReader(headerText))).ReadMIMEHeader()
+	// if err != nil {
+	// 	log.Fatalf("invalid header line: %v", err)
+	// }
+	// for name, values := range h {
+	// 	for _, value := range values {
+	// 		req.Header.Add(name, value)
+	// 	}
+	// }
+
+	req = req.WithContext(ctx)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	for k, v := range resp.Header {
+		fmt.Printf("%v: %v\n", k, v)
+	}
+
+	fmt.Printf("StatusCode %v\n", resp.StatusCode)
+
+	_, err = io.Copy(os.Stdout, resp.Body)
+	if err != nil {
+		log.Fatalf("Read of page body failed: %v\n", err)
+	}
+
+	return nil, nil
+}
+
+func AddLoggerTrace(ctx context.Context) context.Context {
+	t := &trace.DNSClientTrace{
+		QuestionSent: func(question dnsmessage.Question) {
+			fmt.Println("DNS query started for", question.Name.String())
+		},
+		ResponsDone: func(question dnsmessage.Question, msg *dnsmessage.Message, err error) {
+			if err != nil {
+				fmt.Printf("DNS query for %s failed: %v\n", question.Name.String(), err)
+			} else {
+				// Prepare to collect IP addresses
+				var ips []string
+
+				// Iterate over the answer section
+				for _, answer := range msg.Answers {
+					switch rr := answer.Body.(type) {
+					case *dnsmessage.AResource:
+						// Handle IPv4 addresses - convert [4]byte to IP string
+						ipv4 := net.IP(rr.A[:]) // Convert [4]byte to net.IP
+						ips = append(ips, ipv4.String())
+					case *dnsmessage.AAAAResource:
+						// Handle IPv6 addresses - convert [16]byte to IP string
+						ipv6 := net.IP(rr.AAAA[:]) // Convert [16]byte to net.IP
+						ips = append(ips, ipv6.String())
+					}
+				}
+
+				// Print all resolved IP addresses
+				if len(ips) > 0 {
+					fmt.Printf("Resolved IPs for %s: %v\n", question.Name.String(), ips)
+				} else {
+					fmt.Printf("No IPs found for %s\n", question.Name.String())
+				}
+			}
+		},
+		ConnectDone: func(network, addr string, err error) {
+			if err != nil {
+				fmt.Printf("%v Connection to %s failed: %v\n", network, addr, err)
+			} else {
+				fmt.Printf("%v Connection to %s succeeded\n", network, addr)
+			}
+		},
+		WroteDone: func(err error) {
+			if err != nil {
+				fmt.Printf("Write failed: %v\n", err)
+			} else {
+				fmt.Println("Write succeeded")
+			}
+		},
+		ReadDone: func(err error) {
+			if err != nil {
+				fmt.Printf("Read failed: %v\n", err)
+			} else {
+				fmt.Println("Read succeeded")
+			}
+		},
+	}
+
+	// Variables to store the timestamps
+	var startTLS time.Time
+
+	ht := &httptrace.ClientTrace{
+		DNSStart: func(info httptrace.DNSStartInfo) {
+			fmt.Printf("DNS start: %v\n", info)
+		},
+		DNSDone: func(info httptrace.DNSDoneInfo) {
+			fmt.Printf("DNS done: %v\n", info)
+		},
+		ConnectStart: func(network, addr string) {
+			fmt.Printf("Connect start: %v %v\n", network, addr)
+		},
+		ConnectDone: func(network, addr string, err error) {
+			fmt.Printf("Connect done: %v %v %v\n", network, addr, err)
+		},
+		GotFirstResponseByte: func() {
+			fmt.Println("Got first response byte")
+		},
+		WroteHeaderField: func(key string, value []string) {
+			fmt.Printf("Wrote header field: %v %v\n", key, value)
+		},
+		WroteHeaders: func() {
+			fmt.Println("Wrote headers")
+		},
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			fmt.Printf("Wrote request: %v\n", info)
+		},
+		TLSHandshakeStart: func() {
+			startTLS = time.Now()
+		},
+		TLSHandshakeDone: func(state ctls.ConnectionState, err error) {
+			if err != nil {
+				fmt.Printf("TLS handshake failed: %v\n", err)
+			}
+			fmt.Printf("SNI: %v\n", state.ServerName)
+			fmt.Printf("TLS version: %v\n", state.Version)
+			fmt.Printf("ALPN: %v\n", state.NegotiatedProtocol)
+			fmt.Printf("TLS handshake took %v seconds.\n", time.Since(startTLS).Seconds())
+		},
+	}
+
+	tlsTrace := &trace.TLSClientTrace{
+		TLSHandshakeStart: func() {
+			fmt.Println("TLS handshake started")
+			startTLS = time.Now()
+		},
+		TLSHandshakeDone: func(state ctls.ConnectionState, err error) {
+			if err != nil {
+				fmt.Printf("TLS handshake failed: %v\n", err)
+			}
+			fmt.Printf("SNI: %v\n", state.ServerName)
+			fmt.Printf("TLS version: %v\n", state.Version)
+			fmt.Printf("ALPN: %v\n", state.NegotiatedProtocol)
+			fmt.Printf("TLS handshake took %v seconds.\n", time.Since(startTLS).Seconds())
+		},
+	}
+
+	ctx = httptrace.WithClientTrace(ctx, ht)
+	ctx = trace.WithDNSClientTrace(ctx, t)
+	ctx = trace.WithTLSClientTrace(ctx, tlsTrace)
+	return ctx
 }


### PR DESCRIPTION
This PR aims to introduces:

1.  a systematic event-driven approach to collect connection traces that capture events such as establishment of TCP connection, successful read, write, DNS resolution, TLS handshake, etc. 
2. New connectivity tests (`do53-tcp`, `do53-udp`, `dot`, `doh`, `http(s)`)

TODO:

- Make a design decision on what must go into the trace package
- Finalized the ClientTrace retrievers and listeners. Shall we define a set of specialized one (`DNSClientTrace`, `TLSClientTrace`, etc) which is more consistent with `httptrace` approach,  or one generic one? 
-Put these event into a span/trace format suggested and discussed below:
https://opentelemetry.io/docs/concepts/signals/traces/


Here's is an example of trace information getting printed out in `stdio`:

```sh
➜  test-connectivity git:(amir-dsn-trace) ✗ go run . -v  -transport="tls:|socks5://user:pass@pod3.letsgetconnectedquick.com:443" -test-type dot -resolver 1.1.1.1 -report-success-rate 1.0 -domain example.com -resolver-name one.one.one.one
DNS start: {pod3.letsgetconnectedquick.com}
DNS done: {[{45.76.69.216 } {70.34.210.176 }] <nil> false}
Connect start: tcp 45.76.69.216:443
Connect done: tcp 45.76.69.216:443 <nil>
TLS handshake started
SNI: pod3.letsgetconnectedquick.com
TLS version: 772
ALPN: 
TLS handshake took 0.041285625 seconds.
Connected to socks5 proxy at address 45.76.69.216:443
TLS handshake started
SNI: one.one.one.one
TLS version: 772
ALPN: 
TLS handshake took 0.019287583 seconds.
[DEBUG] 2024/08/22 18:43:50.254607 main.go:244: Test Type: dot Resolver Address: 1.1.1.1:853 domain: example.com result: <nil>
{"resolver":"1.1.1.1:853","proto":"tcp","transport":"tls:|socks5://REDACTED@pod3.letsgetconnectedquick.com:443","time":"2024-08-23T01:43:50Z","duration_ms":186,"error":null}
```