### PR TITLE
add ssconf support

### DIFF
--- a/x/examples/outline-cli/outline_device.go
+++ b/x/examples/outline-cli/outline_device.go
@@ -146,7 +146,7 @@ func formatConfig(transportConfig string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return constructShadowsocksSessionConfig(fetched), nil
+		return constructShadowsocksSessionConfig(fetched)
 	default:
 		return "", errors.New("config must start with 'ss://' or 'ssconf://'")
 	}

--- a/x/examples/outline-cli/outline_device.go
+++ b/x/examples/outline-cli/outline_device.go
@@ -15,9 +15,13 @@
 package main
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -42,6 +46,10 @@ type OutlineDevice struct {
 var configToDialer = config.NewDefaultConfigToDialer()
 
 func NewOutlineDevice(transportConfig string) (od *OutlineDevice, err error) {
+	transportConfig, err = formatConfig(transportConfig)
+	if err != nil {
+		return nil, err
+	}
 	ip, err := resolveShadowsocksServerIPFromConfig(transportConfig)
 	if err != nil {
 		return nil, err
@@ -75,21 +83,82 @@ func (d *OutlineDevice) GetServerIP() net.IP {
 	return d.svrIP
 }
 
-func resolveShadowsocksServerIPFromConfig(transportConfig string) (net.IP, error) {
+// based on ssconf spec: https://reddit.com/r/outlinevpn/w/index/dynamic_access_keys
+func constructShadowsocksSessionConfig(resp []byte) (string, error) {
+	var cfg struct {
+		Server     string `json:"server"`
+		ServerPort string `json:"server_port"`
+		Password   string `json:"password"`
+		Method     string `json:"method"`
+		Prefix     string `json:"prefix,omitempty"` // optional
+	}
+
+	if err := json.Unmarshal([]byte(resp), &cfg); err != nil {
+		return "", fmt.Errorf("failed to parse response JSON: %w", err)
+	}
+
+	// TODO: unsure what to do with prefix field
+	var cfgURL url.URL
+	cfgURL.Scheme = "ss"
+	cfgURL.User = url.User(base64.StdEncoding.EncodeToString([]byte(cfg.Method + ":" + cfg.Password)))
+	cfgURL.Host = cfg.Server + ":" + cfg.ServerPort
+
+	return cfgURL.String(), nil
+}
+
+func fetchShadowsocksSessionConfig(transportConfig string) ([]byte, error) {
+	parsed, err := url.Parse(transportConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config URL: %w", err)
+	}
+	parsed.Scheme = "https"
+
+	resp, err := http.Get(parsed.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch config from ssconf: %w", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ready body from request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return body, nil
+}
+
+func formatConfig(transportConfig string) (string, error) {
 	if strings.Contains(transportConfig, "|") {
-		return nil, errors.New("multi-part config is not supported")
+		return "", errors.New("multi-part config is not supported")
 	}
 	if transportConfig = strings.TrimSpace(transportConfig); transportConfig == "" {
-		return nil, errors.New("config is required")
+		return "", errors.New("config is required")
 	}
-	url, err := url.Parse(transportConfig)
+	parsed, err := url.Parse(transportConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse config: %w", err)
+		return "", fmt.Errorf("failed to parse config URL: %w", err)
 	}
-	if url.Scheme != "ss" {
-		return nil, errors.New("config must start with 'ss://'")
+
+	switch parsed.Scheme {
+	case "ss":
+		return transportConfig, nil
+	case "ssconf":
+		fetched, err := fetchShadowsocksSessionConfig(transportConfig)
+		if err != nil {
+			return "", err
+		}
+		return constructShadowsocksSessionConfig(fetched), nil
+	default:
+		return "", errors.New("config must start with 'ss://' or 'ssconf://'")
 	}
-	ipList, err := net.LookupIP(url.Hostname())
+}
+
+func resolveShadowsocksServerIPFromConfig(transportConfig string) (net.IP, error) {
+	parsed, err := url.Parse(transportConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config URL: %w", err)
+	}
+
+	ipList, err := net.LookupIP(parsed.Hostname())
 	if err != nil {
 		return nil, fmt.Errorf("invalid server hostname: %w", err)
 	}


### PR DESCRIPTION
this PR adds support for `ssconf` transport URL to Outline CLI. I was not sure what should be done with the `prefix` field so just left it untouched. I was not able to test the implementation either.

> OutlineVPN CLI (experimental)
[INFO] 2024/08/25 15:12:11 updated global IPv6 support: false
[INFO] 2024/08/25 15:12:11 updated global IPv6 support: true
[ERROR] 2024/08/25 15:12:11 failed to create OutlineDevice: failed to create TCP dialer: failed to decode host string [ss:///*redacted*/@/*redacted*/:8080]: illegal base64 data at input byte 2

using the official access keys I get the above error.
no such issue while using `ssconf` key:
> OutlineVPN CLI (experimental)
[INFO] 2024/08/25 15:58:38 updated global IPv6 support: false
[INFO] 2024/08/25 15:58:41 remote server cannot handle UDP traffic, switch to DNS truncate mode.
[INFO] 2024/08/25 15:58:41 routing traffic from 10.233.233.1 to 10.233.233.2/32 through nic 9
[INFO] 2024/08/25 15:58:41 routing traffic via gw 10.233.233.2 through nic 9...
[INFO] 2024/08/25 15:58:41 ip rule 'from all not to /*redacted*/ via table 233' created

but it doesn't seem to establish any kind of connection at all

OS: OpenSuse Tumbleweed