### PR TITLE
refactor: rename config package

### DIFF
--- a/x/configurl/config.go
+++ b/x/configurl/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"errors"

--- a/x/configurl/config_test.go
+++ b/x/configurl/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"testing"

--- a/x/configurl/dns.go
+++ b/x/configurl/dns.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"context"

--- a/x/configurl/doc.go
+++ b/x/configurl/doc.go
@@ -145,4 +145,4 @@ where wrapStreamDialerWithCustom and wrapPacketDialerWithCustom implement [NewPa
 
 [Onion Routing]: https://en.wikipedia.org/wiki/Onion_routing
 */
-package config
+package configurl

--- a/x/configurl/override.go
+++ b/x/configurl/override.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"context"

--- a/x/configurl/override_test.go
+++ b/x/configurl/override_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"net/url"

--- a/x/configurl/shadowsocks.go
+++ b/x/configurl/shadowsocks.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"encoding/base64"

--- a/x/configurl/shadowsocks_test.go
+++ b/x/configurl/shadowsocks_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"encoding/base64"

--- a/x/configurl/socks5.go
+++ b/x/configurl/socks5.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"net/url"

--- a/x/configurl/split.go
+++ b/x/configurl/split.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"fmt"

--- a/x/configurl/tls.go
+++ b/x/configurl/tls.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"fmt"

--- a/x/configurl/tls_test.go
+++ b/x/configurl/tls_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"net/url"

--- a/x/configurl/websocket.go
+++ b/x/configurl/websocket.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package configurl
 
 import (
 	"context"

--- a/x/examples/fetch-speed/main.go
+++ b/x/examples/fetch-speed/main.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 )
 
 var debugLog log.Logger = *log.New(io.Discard, "", 0)
@@ -58,7 +58,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	dialer, err := config.NewDefaultConfigToDialer().NewStreamDialer(*transportFlag)
+	dialer, err := configurl.NewDefaultConfigToDialer().NewStreamDialer(*transportFlag)
 	if err != nil {
 		log.Fatalf("Could not create dialer: %v\n", err)
 	}

--- a/x/examples/fetch/main.go
+++ b/x/examples/fetch/main.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 )
 
 var debugLog log.Logger = *log.New(io.Discard, "", 0)
@@ -84,7 +84,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	dialer, err := config.NewDefaultConfigToDialer().NewStreamDialer(*transportFlag)
+	dialer, err := configurl.NewDefaultConfigToDialer().NewStreamDialer(*transportFlag)
 	if err != nil {
 		log.Fatalf("Could not create dialer: %v\n", err)
 	}

--- a/x/examples/http2transport/main.go
+++ b/x/examples/http2transport/main.go
@@ -24,7 +24,7 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 	"github.com/Jigsaw-Code/outline-sdk/x/httpproxy"
 )
 
@@ -34,7 +34,7 @@ func main() {
 	urlProxyPrefixFlag := flag.String("urlProxyPrefix", "/proxy", "Path where to run the URL proxy. Set to empty (\"\") to disable it.")
 	flag.Parse()
 
-	dialer, err := config.NewDefaultConfigToDialer().NewStreamDialer(*transportFlag)
+	dialer, err := configurl.NewDefaultConfigToDialer().NewStreamDialer(*transportFlag)
 
 	if err != nil {
 		log.Fatalf("Could not create dialer: %v", err)

--- a/x/examples/outline-cli/outline_device.go
+++ b/x/examples/outline-cli/outline_device.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Jigsaw-Code/outline-sdk/network"
 	"github.com/Jigsaw-Code/outline-sdk/network/lwip2transport"
 	"github.com/Jigsaw-Code/outline-sdk/transport"
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 )
 
 const (
@@ -39,7 +39,7 @@ type OutlineDevice struct {
 	svrIP net.IP
 }
 
-var configToDialer = config.NewDefaultConfigToDialer()
+var configToDialer = configurl.NewDefaultConfigToDialer()
 
 func NewOutlineDevice(transportConfig string) (od *OutlineDevice, err error) {
 	ip, err := resolveShadowsocksServerIPFromConfig(transportConfig)

--- a/x/examples/outline-cli/outline_packet_proxy.go
+++ b/x/examples/outline-cli/outline_packet_proxy.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Jigsaw-Code/outline-sdk/network"
 	"github.com/Jigsaw-Code/outline-sdk/network/dnstruncate"
 	"github.com/Jigsaw-Code/outline-sdk/transport"
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 	"github.com/Jigsaw-Code/outline-sdk/x/connectivity"
 )
 
@@ -36,7 +36,7 @@ type outlinePacketProxy struct {
 func newOutlinePacketProxy(transportConfig string) (opp *outlinePacketProxy, err error) {
 	opp = &outlinePacketProxy{}
 
-	if opp.remotePl, err = config.NewPacketListener(transportConfig); err != nil {
+	if opp.remotePl, err = configurl.NewPacketListener(transportConfig); err != nil {
 		return nil, fmt.Errorf("failed to create UDP packet listener: %w", err)
 	}
 	if opp.remote, err = network.NewPacketProxyFromPacketListener(opp.remotePl); err != nil {

--- a/x/examples/resolve/main.go
+++ b/x/examples/resolve/main.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/dns"
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 	"golang.org/x/net/dns/dnsmessage"
 )
 
@@ -66,7 +66,7 @@ func main() {
 	resolverAddr := *resolverFlag
 
 	var resolver dns.Resolver
-	configToDialer := config.NewDefaultConfigToDialer()
+	configToDialer := configurl.NewDefaultConfigToDialer()
 	if *tcpFlag {
 		streamDialer, err := configToDialer.NewStreamDialer(*transportFlag)
 		if err != nil {

--- a/x/examples/smart-proxy/main.go
+++ b/x/examples/smart-proxy/main.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 	"github.com/Jigsaw-Code/outline-sdk/x/httpproxy"
 	"github.com/Jigsaw-Code/outline-sdk/x/smart"
 )
@@ -86,7 +86,7 @@ func main() {
 		log.Fatalf("Could not read config: %v", err)
 	}
 
-	configToDialer := config.NewDefaultConfigToDialer()
+	configToDialer := configurl.NewDefaultConfigToDialer()
 	packetDialer, err := configToDialer.NewPacketDialer(*transportFlag)
 	if err != nil {
 		log.Fatalf("Could not create packet dialer: %v", err)

--- a/x/examples/test-connectivity/main.go
+++ b/x/examples/test-connectivity/main.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/dns"
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 	"github.com/Jigsaw-Code/outline-sdk/x/connectivity"
 	"github.com/Jigsaw-Code/outline-sdk/x/report"
 )
@@ -161,7 +161,7 @@ func main() {
 	success := false
 	jsonEncoder := json.NewEncoder(os.Stdout)
 	jsonEncoder.SetEscapeHTML(false)
-	configToDialer := config.NewDefaultConfigToDialer()
+	configToDialer := configurl.NewDefaultConfigToDialer()
 	for _, resolverHost := range strings.Split(*resolverFlag, ",") {
 		resolverHost := strings.TrimSpace(resolverHost)
 		resolverAddress := net.JoinHostPort(resolverHost, "53")
@@ -194,7 +194,7 @@ func main() {
 				success = true
 			}
 			debugLog.Printf("Test %v %v result: %v", proto, resolverAddress, result)
-			sanitizedConfig, err := config.SanitizeConfig(*transportFlag)
+			sanitizedConfig, err := configurl.SanitizeConfig(*transportFlag)
 			if err != nil {
 				log.Fatalf("Failed to sanitize config: %v", err)
 			}

--- a/x/examples/ws2endpoint/main.go
+++ b/x/examples/ws2endpoint/main.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 	"golang.org/x/net/websocket"
 )
 
@@ -60,7 +60,7 @@ func main() {
 	defer listener.Close()
 	log.Printf("Proxy listening on %v\n", listener.Addr().String())
 
-	config2Dialer := config.NewDefaultConfigToDialer()
+	config2Dialer := configurl.NewDefaultConfigToDialer()
 	mux := http.NewServeMux()
 	if *tcpPathFlag != "" {
 		dialer, err := config2Dialer.NewStreamDialer(*transportFlag)

--- a/x/httpproxy/connect_handler.go
+++ b/x/httpproxy/connect_handler.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 )
 
 type sanitizeErrorDialer struct {
@@ -52,7 +52,7 @@ func (d *sanitizeErrorDialer) DialStream(ctx context.Context, addr string) (tran
 
 type connectHandler struct {
 	dialer       *sanitizeErrorDialer
-	dialerConfig *config.ConfigToDialer
+	dialerConfig *configurl.ConfigToDialer
 }
 
 var _ http.Handler = (*connectHandler)(nil)
@@ -140,7 +140,7 @@ func (h *connectHandler) ServeHTTP(proxyResp http.ResponseWriter, proxyReq *http
 // the requests using the given [transport.StreamDialer].
 //
 // Clients can specify a Transport header with a value of a transport config as specified in
-// the [config] package to specify the transport for a given request.
+// the [configurl] package to specify the transport for a given request.
 //
 // The resulting handler is currently vulnerable to probing attacks. It's ok as a localhost proxy
 // but it may be vulnerable if used as a public proxy.
@@ -149,7 +149,7 @@ func NewConnectHandler(dialer transport.StreamDialer) http.Handler {
 	// of the base dialer (e.g. access key credentials) to the user.
 	sd := &sanitizeErrorDialer{dialer}
 	// TODO(fortuna): Inject the config parser
-	dialerConfig := config.NewDefaultConfigToDialer()
+	dialerConfig := configurl.NewDefaultConfigToDialer()
 	dialerConfig.BaseStreamDialer = sd
 	return &connectHandler{sd, dialerConfig}
 }

--- a/x/mobileproxy/mobileproxy.go
+++ b/x/mobileproxy/mobileproxy.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 	"github.com/Jigsaw-Code/outline-sdk/x/httpproxy"
 	"github.com/Jigsaw-Code/outline-sdk/x/smart"
 )
@@ -152,7 +152,7 @@ type StreamDialer struct {
 	transport.StreamDialer
 }
 
-var configToDialer = config.NewDefaultConfigToDialer()
+var configToDialer = configurl.NewDefaultConfigToDialer()
 
 // NewStreamDialerFromConfig creates a [StreamDialer] based on the given config.
 // The config format is specified in https://pkg.go.dev/github.com/Jigsaw-Code/outline-sdk/x/config#hdr-Config_Format.

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/Jigsaw-Code/outline-sdk/dns"
 	"github.com/Jigsaw-Code/outline-sdk/transport"
-	"github.com/Jigsaw-Code/outline-sdk/x/config"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
 )
 
 // To test one strategy:
@@ -231,7 +231,7 @@ func (f *StrategyFinder) findTLS(ctx context.Context, testDomains []string, base
 	if len(tlsConfig) == 0 {
 		return nil, errors.New("config for TLS is empty. Please specify at least one transport")
 	}
-	var configToDialer = config.NewDefaultConfigToDialer()
+	var configToDialer = configurl.NewDefaultConfigToDialer()
 	configToDialer.BaseStreamDialer = baseDialer
 
 	ctx, searchDone := context.WithCancel(ctx)


### PR DESCRIPTION
I will introduce a new YML-based config format, so I'd like to rename this one to make it clear which one is which.
I'll likely name the new one `configyml`.

The idea of having a common `config` prefix is to have them grouped together in the package list.

/cc @amircybersec 