### PR TITLE
SOAX relay for remote measurement

### DIFF
--- a/transport/socks5/packet_listener.go
+++ b/transport/socks5/packet_listener.go
@@ -155,7 +155,7 @@ func (c *Client) ListenPacket(ctx context.Context) (net.PacketConn, error) {
 	// https://datatracker.ietf.org/doc/html/rfc1928#section-6
 	// Whoile binding address to specific client address has its advantages, it also creates some
 	// challenges such as NAT traveral if client is behind NAT.
-	sc, bindAddr, err := c.connectAndRequest(ctx, CmdUDPAssociate, "0.0.0.0:0")
+	sc, bindAddr, err := c.ConnectAndRequest(ctx, CmdUDPAssociate, "0.0.0.0:0")
 	if err != nil {
 		return nil, err
 	}

--- a/transport/socks5/stream_dialer.go
+++ b/transport/socks5/stream_dialer.go
@@ -209,7 +209,7 @@ func (c *Client) request(conn io.ReadWriter, cmd byte, dstAddr string) (*address
 }
 
 // connectAndRequest manages the connection lifecycle and delegates the SOCKS5 communication to the request function.
-func (c *Client) connectAndRequest(ctx context.Context, cmd byte, dstAddr string) (transport.StreamConn, *address, error) {
+func (c *Client) ConnectAndRequest(ctx context.Context, cmd byte, dstAddr string) (transport.StreamConn, *address, error) {
 	proxyConn, err := c.se.ConnectStream(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not connect to SOCKS5 proxy: %w", err)
@@ -230,7 +230,7 @@ func (c *Client) connectAndRequest(ctx context.Context, cmd byte, dstAddr string
 // The returned [error] will be of type [ReplyCode] if the server sends a SOCKS error reply code, which
 // you can check against the error constants in this package using [errors.Is].
 func (c *Client) DialStream(ctx context.Context, dstAddr string) (transport.StreamConn, error) {
-	proxyConn, _, err := c.connectAndRequest(ctx, CmdConnect, dstAddr)
+	proxyConn, _, err := c.ConnectAndRequest(ctx, CmdConnect, dstAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/x/examples/soax-relay/README.md
+++ b/x/examples/soax-relay/README.md
@@ -1,0 +1,131 @@
+# SOCKS5 Proxy Relay for SOAX
+
+This program creates a SOCKS5 proxy relay that allows users to share access to SOAX without sharing their own credentials. It's designed for connectivity testing purposes.
+
+## Design
+
+The proxy relay works as follows:
+
+1. It listens for incoming SOCKS5 connections on a specified local address and port.
+2. It authenticates incoming connections using a custom authentication mechanism.
+3. For authenticated connections, it relays requests to the SOAX proxy server.
+4. It supports both TCP and UDP traffic.
+
+#### Key components:
+
+- **CustomAuthenticator**: Handles authentication based on username prefix and extracts the suffix which includes connection parameters such as country, city, ISP, etc.
+- **StaticCredentialStore**: Stores and validates user credentials.
+- **UDP Associate Handler**: Manages UDP connections by relaying the SOAX bind address back to the client.
+
+## Usage
+
+### Configuration
+
+The program uses a YAML configuration file (`config.yaml`) for settings. Example configuration:
+
+```yaml
+server:
+  address: "127.0.0.1"
+  port: "1080"
+
+upstream:
+  prefix: "package-xxxxx-"
+  password: "YourSOAXPassword"
+  address: "proxy.soax.com:5000"
+
+credentials:
+  foo: "bar"
+  jane: "password123"
+
+udp_timeout: 1m
+```
+
+### Authentication
+Users connect to the relay using the following format:
+
+<b>Username:</b> 
+
+username-country-{cc_code}-sessionid-{session_id}-sessionlength-{time_in_sec}
+
+where any part that goes after username-country-{cc_code} is optional. For more information on the format refer to [this document](https://helpcenter.soax.com/en/articles/6723733-sticky-sessions) on soax support page.
+
+<b>Password:</b> (as defined in the credentials section of the config file)
+
+<b>Example Username:</b>
+
+outline-country-ru-sessionid-12-sessionlength-600
+
+The relay will use the SOAX package ID and password to connect to the SOAX server, appending the country, sessionid, and sessionlength from the user's input.
+
+### Setup and Running
+
+Ensure you have Go installed on your system.
+Clone the repository:
+
+```bash
+git clone <repository-url>
+cd <repository-directory>
+```
+
+Install dependencies:
+```bash
+go mod tidy
+```
+
+Create a `config.yaml` file in the project directory with your SOAX credentials and desired settings.
+
+Build the program:
+
+```bash
+go build -o socks5relay
+```
+
+Run the program:
+
+```bash
+./socks5relay
+```
+
+
+The relay will start and listen for incoming connections on the specified address and port.
+
+SOAX Sticky Sessions:
+
+This relay supports SOAX sticky sessions. Users can specify:
+
+1. country
+
+Two-letter country code (e.g., "us" for United States)
+
+2. sessionid
+
+A random string to maintain the same IP across requests
+
+3. sessionlength
+
+Duration of the session in seconds (10 to 3600)
+
+4. city
+
+City name. Example: new+york
+
+5. region
+
+Region name. Example: new+york
+
+6. isp
+
+ISP name. Please use this parameter together with the country information. 
+
+For more information on the format for values please check out [this document](https://helpcenter.soax.com/en/articles/6723733-sticky-sessions) on soax support page.
+
+The relay will forward these parameters to SOAX, allowing users to benefit from sticky sessions without direct access to SOAX credentials.
+
+### Security Considerations
+
+This relay is intended for testing purposes only.
+Ensure the relay is run in a secure environment, as it handles sensitive SOAX credentials.
+Regularly update the credentials in the config file to maintain security.
+
+
+

--- a/x/examples/soax-relay/config.yaml
+++ b/x/examples/soax-relay/config.yaml
@@ -1,0 +1,14 @@
+server:
+  address: 127.0.0.1
+  port: 1080
+
+soax:
+  package: package-000000-
+  password: XXXXXXXX
+  address: proxy.soax.com:5000
+
+credentials:
+  foo: bar
+  exampleuser: examplepass
+
+udp_timeout: 1m

--- a/x/examples/soax-relay/main.go
+++ b/x/examples/soax-relay/main.go
@@ -1,0 +1,260 @@
+// Copyright 2023 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+	csocks5 "github.com/Jigsaw-Code/outline-sdk/transport/socks5"
+	"github.com/spf13/viper"
+	"github.com/things-go/go-socks5"
+	"github.com/things-go/go-socks5/statute"
+)
+
+// CustomAuthenticator handles authentication based on username prefix and extracts the suffix
+type CustomAuthenticator struct {
+	PrefixCredentials CredentialStore // Store for validating the prefix part of the username
+}
+
+// GetCode implements the `GetCode` method for the `Authenticator` interface
+func (a CustomAuthenticator) GetCode() uint8 {
+	return statute.MethodUserPassAuth
+}
+
+// Authenticate checks if the username matches a required prefix and extracts the suffix
+func (a CustomAuthenticator) Authenticate(reader io.Reader, writer io.Writer, userAddr string) (*socks5.AuthContext, error) {
+	// Respond to the client to use username/password authentication
+	if _, err := writer.Write([]byte{statute.VersionSocks5, statute.MethodUserPassAuth}); err != nil {
+		return nil, err
+	}
+
+	// Parse the username and password from the client request
+	nup, err := statute.ParseUserPassRequest(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	fullUsername := string(nup.User)
+	password := string(nup.Pass)
+
+	// Split the username into prefix and suffix parts
+	parts := strings.SplitN(fullUsername, "-", 2)
+	if len(parts) < 2 {
+		if _, err := writer.Write([]byte{statute.UserPassAuthVersion, statute.AuthFailure}); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("username does not contain a valid prefix-suffix format")
+	}
+
+	usernamePrefix := parts[0] // Prefix (e.g., "jane")
+	usernameSuffix := parts[1] // Suffix (e.g., "-country-ir")
+
+	log.Printf("Attempting authentication with prefix: %s and suffix: %s", usernamePrefix, usernameSuffix)
+
+	// Validate the prefix and password against stored credentials
+	if !a.PrefixCredentials.Valid(usernamePrefix, password, userAddr) {
+		// Authentication failed
+		if _, err := writer.Write([]byte{statute.UserPassAuthVersion, statute.AuthFailure}); err != nil {
+			return nil, err
+		}
+		return nil, statute.ErrUserAuthFailed
+	}
+
+	// Authentication successful
+	if _, err := writer.Write([]byte{statute.UserPassAuthVersion, statute.AuthSuccess}); err != nil {
+		return nil, err
+	}
+
+	// Return the context with the extracted suffix for later use
+	return &socks5.AuthContext{
+		Method: statute.MethodUserPassAuth,
+		Payload: map[string]string{
+			"suffix": usernameSuffix, // Store the suffix for later use in the dialer
+			"prefix": usernamePrefix, // Store the prefix as well, if needed
+		},
+	}, nil
+}
+
+// CredentialStore is an interface to validate prefix-based credentials
+type CredentialStore interface {
+	Valid(username, password, userAddr string) bool
+}
+
+// StaticCredentialStore is a simple credential store that holds a map of valid prefixes and passwords
+type StaticCredentialStore struct {
+	credentials map[string]string // Maps username/prefix to password
+}
+
+// Valid checks if the provided prefix and password are valid
+func (s *StaticCredentialStore) Valid(prefix, password, userAddr string) bool {
+	storedPassword, exists := s.credentials[prefix]
+	return exists && storedPassword == password
+}
+
+func udpAssociateHandler(ctx context.Context, writer io.Writer, request *socks5.Request) error {
+	// Extract the suffix from the auth context
+	suffix, ok := request.AuthContext.Payload["suffix"]
+	if !ok {
+		return errors.New("no suffix found in auth context")
+	}
+
+	soaxPackage := viper.GetString("soax.package")
+	soaxPassword := viper.GetString("soax.password")
+	soaxAddress := viper.GetString("soax.address")
+
+	// Construct the upstream soax username by concatenating
+	// the soax package name with the suffix
+	soaxUsername := soaxPackage + suffix
+	log.Printf("Sending associate command with username: %s\n", soaxUsername)
+
+	streamEndpoint := transport.StreamDialerEndpoint{Dialer: &transport.TCPDialer{}, Address: soaxAddress}
+	client, err := csocks5.NewClient(&streamEndpoint)
+	if err != nil {
+		return err
+	}
+
+	err = client.SetCredentials([]byte(soaxUsername), []byte(soaxPassword))
+	if err != nil {
+		return err
+	}
+
+	client.EnablePacket(&transport.UDPDialer{})
+
+	conn, bindAddr, err := client.ConnectAndRequest(ctx, csocks5.CmdUDPAssociate, "0.0.0.0:0")
+	if err != nil {
+		return err
+	}
+
+	// Start a goroutine to close the connection after a timeout
+	go func() {
+		timeout := viper.GetDuration("udp_timeout")
+		<-time.After(timeout)
+		log.Println("Closing UDP associate connection after timeout")
+		conn.Close()
+	}()
+
+	if err = socks5.SendReply(writer, statute.RepSuccess, convertToNetAddr("udp", bindAddr.IP, bindAddr.Port)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func convertToNetAddr(network string, ip netip.Addr, port uint16) net.Addr {
+	// Convert netip.Addr to net.IP
+	netIP := ip.AsSlice()
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		// Create a net.TCPAddr
+		tcpAddr := &net.TCPAddr{
+			IP:   netIP,
+			Port: int(port),
+		}
+		return tcpAddr
+	case "udp", "udp4", "udp6":
+		// Create a net.UDPAddr
+		udpAddr := &net.UDPAddr{
+			IP:   netIP,
+			Port: int(port),
+		}
+		return udpAddr
+	}
+	return nil
+}
+
+func loadConfig() error {
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+	viper.AddConfigPath(".")
+
+	if err := viper.ReadInConfig(); err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+	return nil
+}
+
+func main() {
+
+	if err := loadConfig(); err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	creds := &StaticCredentialStore{
+		credentials: viper.GetStringMapString("credentials"),
+	}
+
+	// Create the custom authenticator
+	customAuth := CustomAuthenticator{
+		PrefixCredentials: creds,
+	}
+
+	server := socks5.NewServer(
+		socks5.WithAuthMethods([]socks5.Authenticator{customAuth}),
+		socks5.WithLogger(socks5.NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
+		socks5.WithDialAndRequest(func(ctx context.Context, network, addr string, req *socks5.Request) (net.Conn, error) {
+			authContext := req.AuthContext
+			if authContext == nil {
+				return nil, errors.New("no auth context available")
+			}
+
+			suffix, ok := authContext.Payload["suffix"]
+			if !ok {
+				return nil, errors.New("no suffix found in auth context")
+			}
+
+			soaxpackage := viper.GetString("soax.package")
+			soaxPassword := viper.GetString("soax.password")
+			soaxAddress := viper.GetString("soax.address")
+
+			// Construct the upstream username by concatenating the base username with the suffix
+			soaxUsername := soaxpackage + suffix // e.g., "package-189365-country-ir-seesionid-..."
+
+			switch network {
+			case "tcp", "tcp4", "tcp6":
+				streamEndpoint := transport.StreamDialerEndpoint{Dialer: &transport.TCPDialer{}, Address: soaxAddress}
+				client, err := csocks5.NewClient(&streamEndpoint)
+				if err != nil {
+					return nil, err
+				}
+
+				err = client.SetCredentials([]byte(soaxUsername), []byte(soaxPassword))
+				if err != nil {
+					return nil, err
+				}
+				return client.DialStream(ctx, addr)
+			default:
+				return nil, fmt.Errorf("unsupported network: %s", network)
+			}
+		}),
+		socks5.WithAssociateHandle(udpAssociateHandler),
+	)
+
+	// Run SOCKS5 proxy on the specified address and port
+	listeningAddr := fmt.Sprintf("%s:%s", viper.GetString("server.address"), viper.GetString("server.port"))
+	if err := server.ListenAndServe("tcp", listeningAddr); err != nil {
+		panic(err)
+	}
+
+}


### PR DESCRIPTION
This PR adds an example for running a socks5 proxy that forwards requests to soax server socks5 server. It helps with temporarily sharing access with others to let them perform measurements on a given network. 