### PR TITLE
fix: try base64 legacy decoding for maximum compatibility

### DIFF
--- a/x/configurl/shadowsocks.go
+++ b/x/configurl/shadowsocks.go
@@ -148,6 +148,10 @@ func parseShadowsocksSIP002URL(url *url.URL) (*shadowsocksConfig, error) {
 	// Cipher info can be optionally encoded with Base64URL.
 	encoding := base64.URLEncoding.WithPadding(base64.NoPadding)
 	decodedUserInfo, err := encoding.DecodeString(userInfo)
+	if err != nil {
+		// Try base64 decoding in legacy mode
+		decodedUserInfo, err = base64.StdEncoding.DecodeString(userInfo)
+	}
 	var cipherInfo string
 	if err == nil {
 		cipherInfo = string(decodedUserInfo)

--- a/x/configurl/shadowsocks_test.go
+++ b/x/configurl/shadowsocks_test.go
@@ -64,6 +64,31 @@ func TestParseShadowsocksURLUserInfoEncoded(t *testing.T) {
 	require.Equal(t, "HTTP/1.1 ", string(config.prefix))
 }
 
+func TestParseShadowsocksURLUserInfoLegacyEncoded(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("aes-256-gcm:shadowsocks"))
+	urls, err := parseConfig("ss://" + string(encoded) + "@example.com:1234?prefix=HTTP%2F1.1%20" + "#outline-123")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(urls))
+
+	config, err := parseShadowsocksURL(urls[0])
+
+	require.NoError(t, err)
+	require.Equal(t, "example.com:1234", config.serverAddress)
+	require.Equal(t, "HTTP/1.1 ", string(config.prefix))
+}
+
+func TestLegacyEncodedShadowsocksURL(t *testing.T) {
+	configString := "ss://YWVzLTEyOC1nY206c2hhZG93c29ja3M=@example.com:1234"
+	urls, err := parseConfig(configString)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(urls))
+
+	config, err := parseShadowsocksURL(urls[0])
+
+	require.NoError(t, err)
+	require.Equal(t, "example.com:1234", config.serverAddress)
+}
+
 func TestParseShadowsocksURLNoEncoding(t *testing.T) {
 	configString := "ss://aes-256-gcm:1234567@example.com:1234"
 	urls, err := parseConfig(configString)


### PR DESCRIPTION
Currently <b> Outline SDK </b> config parser fails for strings encoded in legacy base64 mode such as the example below:

```
ss://YWVzLTEyOC1nY206c2hhZG93c29ja3M=@210.100.100.100:443
```

Current Outline client is however able to parse and decode the above URL. For consistent behaviour between Outline SDK and Outline client, I have added a secondary decoding step if current method fails. 


Current aproach:
```go
encoding := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(userInfo)
```

Backup approach:
```go
encoding := base64.StdEncoding.WithPadding(base64.NoPadding).DecodeString(userInfo)
```