### PR TITLE
Tls rootca option

### DIFF
--- a/transport/tls/stream_dialer.go
+++ b/transport/tls/stream_dialer.go
@@ -94,6 +94,8 @@ type ClientConfig struct {
 	NextProtos []string
 	// The cache for sessin resumption.
 	SessionCache tls.ClientSessionCache
+	// The root certificate authorities for client to use for certificate verification.
+	RootCAs *x509.CertPool
 }
 
 // toStdConfig creates a [tls.Config] based on the configured parameters.
@@ -102,6 +104,7 @@ func (cfg *ClientConfig) toStdConfig() *tls.Config {
 		ServerName:         cfg.ServerName,
 		NextProtos:         cfg.NextProtos,
 		ClientSessionCache: cfg.SessionCache,
+		RootCAs:            cfg.RootCAs,
 		// Set InsecureSkipVerify to skip the default validation we are
 		// replacing. This will not disable VerifyConnection.
 		InsecureSkipVerify: true,
@@ -186,5 +189,12 @@ func WithSessionCache(sessionCache tls.ClientSessionCache) ClientOption {
 func WithCertificateName(hostname string) ClientOption {
 	return func(_ string, config *ClientConfig) {
 		config.CertificateName = hostname
+	}
+}
+
+// WithRootCAs sets the root certificate authorities for the client to use for certificate verification.
+func WithRootCAs(rootCAs *x509.CertPool) ClientOption {
+	return func(_ string, config *ClientConfig) {
+		config.RootCAs = rootCAs
 	}
 }

--- a/transport/tls/stream_dialer_test.go
+++ b/transport/tls/stream_dialer_test.go
@@ -140,6 +140,14 @@ func TestWithALPN(t *testing.T) {
 	require.Equal(t, []string{"h2", "http/1.1"}, cfg.NextProtos)
 }
 
+func TestWithRootCAs(t *testing.T) {
+	var cfg ClientConfig
+	rootCAs := x509.NewCertPool()
+	rootCAs.AddCert(&x509.Certificate{})
+	WithRootCAs(rootCAs)("", &cfg)
+	require.True(t, rootCAs.Equal(cfg.RootCAs))
+}
+
 // Make sure there are no connection leakage in DialStream
 func TestDialStreamCloseInnerConnOnError(t *testing.T) {
 	inner := &connCounterDialer{base: &transport.TCPDialer{}}

--- a/transport/tls/stream_dialer_test.go
+++ b/transport/tls/stream_dialer_test.go
@@ -19,8 +19,9 @@ import (
 	"crypto/x509"
 	"testing"
 
-	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
 )
 
 func TestDomain(t *testing.T) {
@@ -145,7 +146,7 @@ func TestWithRootCAs(t *testing.T) {
 	rootCAs := x509.NewCertPool()
 	rootCAs.AddCert(&x509.Certificate{})
 	WithRootCAs(rootCAs)("", &cfg)
-	require.True(t, rootCAs.Equal(cfg.RootCAs))
+	require.Equal(t, rootCAs, cfg.RootCAs)
 }
 
 // Make sure there are no connection leakage in DialStream


### PR DESCRIPTION
This adds a way to include a custom Root CA to the TLS transport. (#315)