### PR TITLE
feat(x): use endpoint instead of dialer for websocket

### DIFF
--- a/x/configurl/websocket.go
+++ b/x/configurl/websocket.go
@@ -72,7 +72,7 @@ func registerWebsocketStreamDialer(r TypeRegistry[transport.StreamDialer], typeI
 		}
 		return transport.FuncStreamDialer(func(ctx context.Context, addr string) (transport.StreamConn, error) {
 			wsURL := url.URL{Scheme: "ws", Host: addr, Path: wsConfig.tcpPath}
-			connect, err := websocket.NewStreamEndpoint(wsURL.String(), sd)
+			connect, err := websocket.NewStreamEndpoint(wsURL.String(), &transport.StreamDialerEndpoint{Address: addr, Dialer: sd})
 			if err != nil {
 				return nil, fmt.Errorf("failed to create websocket stream endpoint: %w", err)
 			}
@@ -96,7 +96,7 @@ func registerWebsocketPacketDialer(r TypeRegistry[transport.PacketDialer], typeI
 		}
 		return transport.FuncPacketDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			wsURL := url.URL{Scheme: "ws", Host: addr, Path: wsConfig.udpPath}
-			connect, err := websocket.NewPacketEndpoint(wsURL.String(), sd)
+			connect, err := websocket.NewPacketEndpoint(wsURL.String(), &transport.StreamDialerEndpoint{Address: addr, Dialer: sd})
 			if err != nil {
 				return nil, fmt.Errorf("failed to create websocket stream endpoint: %w", err)
 			}

--- a/x/websocket/endpoint_test.go
+++ b/x/websocket/endpoint_test.go
@@ -91,7 +91,8 @@ func Test_NewStreamEndpoint(t *testing.T) {
 	// 	},
 	// }
 	client := ts.Client()
-	connect, err := NewStreamEndpoint("wss"+ts.URL[5:]+"/tcp", &transport.TCPDialer{}, WithTLSConfig(client.Transport.(*http.Transport).TLSClientConfig))
+	endpoint := &transport.TCPEndpoint{Address: ts.Listener.Addr().String()}
+	connect, err := NewStreamEndpoint("wss"+ts.URL[5:]+"/tcp", endpoint, WithTLSConfig(client.Transport.(*http.Transport).TLSClientConfig))
 	require.NoError(t, err)
 	require.NotNil(t, connect)
 
@@ -142,7 +143,8 @@ func Test_NewPacketEndpoint(t *testing.T) {
 	defer ts.Close()
 
 	client := ts.Client()
-	connect, err := NewPacketEndpoint("wss"+ts.URL[5:]+"/udp", &transport.TCPDialer{}, WithTLSConfig(client.Transport.(*http.Transport).TLSClientConfig))
+	endpoint := &transport.TCPEndpoint{Address: ts.Listener.Addr().String()}
+	connect, err := NewPacketEndpoint("wss"+ts.URL[5:]+"/udp", endpoint, WithTLSConfig(client.Transport.(*http.Transport).TLSClientConfig))
 	require.NoError(t, err)
 	require.NotNil(t, connect)
 


### PR DESCRIPTION
This allows us to easily specify a different endpoint in the client to bypass dns-based blocking and can allow for further optimizations (like session/connection reuse) more easily in the future