### PR TITLE
Fixed double mutex acquisition deadlock when recreating UDP session

### DIFF
--- a/network/lwip2transport/udp.go
+++ b/network/lwip2transport/udp.go
@@ -55,13 +55,15 @@ func (h *udpHandler) ReceiveTo(tunConn lwip.UDPConn, data []byte, destAddr *net.
 
 	h.mu.Lock()
 	reqSender, ok := h.senders[laddr]
+	h.mu.Unlock()
 	if !ok {
 		if reqSender, err = h.newSession(tunConn); err != nil {
 			return
 		}
+		h.mu.Lock()
 		h.senders[laddr] = reqSender
+		h.mu.Unlock()
 	}
-	h.mu.Unlock()
 
 	_, err = reqSender.WriteTo(data, destAddr.AddrPort())
 	return

--- a/network/lwip2transport/udp.go
+++ b/network/lwip2transport/udp.go
@@ -55,6 +55,7 @@ func (h *udpHandler) ReceiveTo(tunConn lwip.UDPConn, data []byte, destAddr *net.
 
 	h.mu.Lock()
 	reqSender, ok := h.senders[laddr]
+	// TODO: address synchronization issues with h.senders[laddr] and the following `if` in the future
 	h.mu.Unlock()
 	if !ok {
 		if reqSender, err = h.newSession(tunConn); err != nil {

--- a/x/examples/outline-cli/routing_linux.go
+++ b/x/examples/outline-cli/routing_linux.go
@@ -113,6 +113,8 @@ func setupIpRule(svrIp string, routingTable, routingPriority int) error {
 	ipRule.Invert = true
 
 	if err := netlink.RuleAdd(ipRule); err != nil {
+		// assuming duplicate from previous run, just to make sure it does not stays stale forever in the routing table
+		defer cleanUpRule()
 		return fmt.Errorf("failed to add IP rule (table %v, dst %v): %w", ipRule.Table, ipRule.Dst, err)
 	}
 	logging.Info.Printf("ip rule 'from all not to %v via table %v' created\n", ipRule.Dst, ipRule.Table)


### PR DESCRIPTION
minor: Opportunistically clean-up stale route rule in outline-cli
closes #342