### PR TITLE
fix(x): return `ErrClosed` for abnormal closures

### DIFF
--- a/x/websocket/endpoint.go
+++ b/x/websocket/endpoint.go
@@ -161,7 +161,7 @@ func (c *gorillaConn) Read(buf []byte) (int, error) {
 	if err != nil {
 		var closeError *websocket.CloseError
 		if errors.As(err, &closeError) {
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+			if closeError.Code == websocket.CloseNormalClosure {
 				return 0, io.EOF
 			}
 			return 0, fmt.Errorf("%w %w", net.ErrClosed, closeError)

--- a/x/websocket/endpoint.go
+++ b/x/websocket/endpoint.go
@@ -159,11 +159,12 @@ func (c *gorillaConn) Read(buf []byte) (int, error) {
 		return 0, c.readErr
 	}
 	if err != nil {
-		if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-			return 0, io.EOF
-		}
-		if websocket.IsUnexpectedCloseError(err) {
-			return 0, net.ErrClosed
+		var closeError *websocket.CloseError
+		if errors.As(err, &closeError) {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+				return 0, io.EOF
+			}
+			return 0, fmt.Errorf("%w %w", net.ErrClosed, closeError)
 		}
 		return 0, err
 	}

--- a/x/websocket/endpoint.go
+++ b/x/websocket/endpoint.go
@@ -159,9 +159,11 @@ func (c *gorillaConn) Read(buf []byte) (int, error) {
 		return 0, c.readErr
 	}
 	if err != nil {
-		var closeError *websocket.CloseError
-		if errors.As(err, &closeError) && closeError.Code == websocket.CloseNormalClosure {
+		if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
 			return 0, io.EOF
+		}
+		if websocket.IsUnexpectedCloseError(err) {
+			return 0, net.ErrClosed
 		}
 		return 0, err
 	}


### PR DESCRIPTION
Errors returned from a Gorilla connection's `NextReader()` call require applications to break out of the application's read loop, as errors are permanent. Subsequent calls return the same error and after 1000 calls panic:

```
Feb 24 23:33:38.357 INF http: panic serving 127.0.0.1:57514: repeated read on failed websock
et connection                                                                               
goroutine 180 [running]:                                                                    
net/http.(*conn).serve.func1()                                                              
        /usr/lib/google-golang/src/net/http/server.go:1924 +0xd3                            
panic({0xa14340?, 0xb87160?})                                                               
        /usr/lib/google-golang/src/runtime/panic.go:799 +0x132                              
github.com/gorilla/websocket.(*Conn).NextReader(0xc0004b3600)                               
        /usr/local/google/home/sbruens/go/pkg/mod/github.com/gorilla/websocket@v1.5.3/conn.g
o:1030 +0x1fe                                                                               
github.com/Jigsaw-Code/outline-sdk/x/websocket.(*gorillaConn).Read(0xc000362d00, {0xc0003920
00, 0x10000, 0x10000})                                                                      
        /usr/local/google/home/sbruens/outline/outline-sdk/x/websocket/endpoint.go:157 +0xd1
github.com/Jigsaw-Code/outline-ss-server/service.(*associationHandler).HandleAssociation(0xc
00021ad80, {0xb8c620, 0xc00014f130}, {0x7f800f23c818, 0xc000368320}, {0xb8c8f8, 0xc000201320
})                                                                                          
        /usr/local/google/home/sbruens/outline/outline-ss-server/service/udp.go:162 +0x2da  
main.(*OutlineServer).runConfig.func1.2.8({0xb8bee8?, 0xc00029ca80?}, 0xc0000fb540)         
        /usr/local/google/home/sbruens/outline/outline-ss-server/cmd/outline-ss-server/main.
go:376 +0x2ba                                                                               
net/http.HandlerFunc.ServeHTTP(0xc0000fb540?, {0xb8bee8?, 0xc00029ca80?}, 0xab3720?)        
        /usr/lib/google-golang/src/net/http/server.go:2271 +0x29                            
main.(*OutlineServer).runConfig.func1.2.ProxyHeaders.23({0xb8bee8, 0xc00029ca80}, 0xc0000fb5
40)                                                                                         
        /usr/local/google/home/sbruens/go/pkg/mod/github.com/gorilla/handlers@v1.4.1/proxy_h
eaders.go:59 +0x143                                                                         
net/http.HandlerFunc.ServeHTTP(0x0?, {0xb8bee8?, 0xc00029ca80?}, 0xb?)                      
        /usr/lib/google-golang/src/net/http/server.go:2271 +0x29
main.(*OutlineServer).runConfig.func1.2.StripPrefix.24({0xb8bee8, 0xc00029ca80}, 0xc0000fb40
0)
        /usr/lib/google-golang/src/net/http/server.go:2333 +0x262
net/http.HandlerFunc.ServeHTTP(0xc00029c000?, {0xb8bee8?, 0xc00029ca80?}, 0x807856?)
        /usr/lib/google-golang/src/net/http/server.go:2271 +0x29
net/http.(*ServeMux).ServeHTTP(0x5ca179?, {0xb8bee8, 0xc00029ca80}, 0xc0000fb400)
        /usr/lib/google-golang/src/net/http/server.go:2801 +0x1c7
net/http.serverHandler.ServeHTTP({0xc000211f50?}, {0xb8bee8?, 0xc00029ca80?}, 0x6?)
        /usr/lib/google-golang/src/net/http/server.go:3281 +0x8e
net/http.(*conn).serve(0xc000373440, {0xb8c5e8, 0xc00011e3f0})
        /usr/lib/google-golang/src/net/http/server.go:2079 +0x625
created by net/http.(*Server).Serve in goroutine 44
        /usr/lib/google-golang/src/net/http/server.go:3436 +0x4bc
```

So we return `net.ErrClosed` error for all other close errors. This will ensure the UDP loop knows to exit as the connection has closed.