### PR TITLE
fix: example command in stream dialer

### DIFF
--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -32,7 +32,7 @@ import (
 )
 
 // To test one strategy:
-// go run ./x/examples/smart-proxy -v -localAddr=localhost:1080 --transport="" --domain www.rferl.org  --config=<(echo '{"dns": [{"https": {"name": "doh.sb"}}]}')
+// go run -C ./x/examples/smart-proxy/ . -v -localAddr=localhost:1080 --transport="" --domain www.rferl.org  --config=<(echo '{"dns": [{"https": {"name": "doh.sb"}}]}')
 
 type StrategyFinder struct {
 	TestTimeout  time.Duration


### PR DESCRIPTION
As written it errors

`main module (github.com/Jigsaw-Code/outline-sdk) does not contain package github.com/Jigsaw-Code/outline-sdk/x/examples/smart-proxy`