### PR TITLE
feat(x): Parse psiphon config format as part of smart-proxy

### DIFF
--- a/x/examples/smart-proxy/config_broken.yaml
+++ b/x/examples/smart-proxy/config_broken.yaml
@@ -24,18 +24,12 @@ tls:
 
 fallback:
   # Nonexistent Outline Server
-  - configUrl: ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1
-  # Nonexistant Psiphon Config. Not yet supported
+  - ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1
+  # Nonexistant Psiphon Config JSON. Not yet supported
   - psiphon: {
-      LocalHttpProxyPort: 8081,
-      LocalSocksProxyPort: 1081,
-      PropagationChannelId: FFFFFFFFFFFFFFFF,
-      RemoteServerListDownloadFilename: remote_server_list,
-      RemoteServerListSignaturePublicKey: MIICIDANBgkqhkiG9w0BAQEFAAOCAg0AMIICCAKCAgEAt7Ls+/39r+T6zNW7GiVpJfzq/xvL9SBH5rIFnk0RXYEYavax3WS6HOD35eTAqn8AniOwiH +DOkvgSKF2caqk/y1dfq47Pdymtwzp9ikpB1C5OfAysXzBiwVJlCdajBKvBZDerV1cMvRzCKvKwRmvDmHgphQQ7WfXIGbRbmmk6opMBh3roE42KcotLFtqp0RRwLtcBRNtCdsrVsjiI1Lqz/lH+T61sGjSjQ3CHMuZYSQJZo/KrvzgQXpkaCTdbObxHqb6/+i1qaVOfEsvjoiyzTxJADvSytVtcTjijhPEV6XskJVHE1Zgl+7rATr/pDQkw6DPCNBS1+Y6fy7GstZALQXwEDN/qhQI9kWkHijT8ns+i1vGg00Mk/6J75arLhqcodWsdeG/M/moWgqQAnlZAGVtJI1OgeF5fsPpXu4kctOfuZlGjVZXQNW34aOzm8r8S0eVZitPlbhcPiR4gT/aSMz/wd8lZlzZYsje/Jr8u/YtlwjjreZrGRmG8KMOzukV3lLmMppXFMvl4bxv6YFEmIuTsOhbLTwFgh7KYNjodLj/LsqRVfwz31PgWQFTEPICV7GCvgVlPRxnofqKSjgTWI4mxDhBpVcATvaoBl1L/6WLbFvBsoAUBItWwctO2xalKxF5szhGm8lccoc5MZr8kfE0uxMgsxz4er68iCID+rsCAQM=,
-      RemoteServerListUrl: https://s3.amazonaws.com//psiphon/web/mjr4-p23r-puwl/server_list_compressed,
-      SponsorId: FFFFFFFFFFFFFFFF,
-      UseIndistinguishableTLS: true
+      "PropagationChannelId":"FFFFFFFFFFFFFFFF",
+      "SponsorId":"FFFFFFFFFFFFFFFF",
     }
   # Nonexistant local socks5 proxy
-  - configUrl: socks5://192.168.1.10:1080
+  - socks5://192.168.1.10:1080
 

--- a/x/examples/smart-proxy/config_broken.yaml
+++ b/x/examples/smart-proxy/config_broken.yaml
@@ -23,5 +23,19 @@ tls:
   - tlsfrag:1
 
 fallback:
-  # Nonexistent server
-  - ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1
+  # Nonexistent Outline Server
+  - configUrl: ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1
+  # Nonexistant Psiphon Config. Not yet supported
+  - psiphon: {
+      LocalHttpProxyPort: 8081,
+      LocalSocksProxyPort: 1081,
+      PropagationChannelId: FFFFFFFFFFFFFFFF,
+      RemoteServerListDownloadFilename: remote_server_list,
+      RemoteServerListSignaturePublicKey: MIICIDANBgkqhkiG9w0BAQEFAAOCAg0AMIICCAKCAgEAt7Ls+/39r+T6zNW7GiVpJfzq/xvL9SBH5rIFnk0RXYEYavax3WS6HOD35eTAqn8AniOwiH +DOkvgSKF2caqk/y1dfq47Pdymtwzp9ikpB1C5OfAysXzBiwVJlCdajBKvBZDerV1cMvRzCKvKwRmvDmHgphQQ7WfXIGbRbmmk6opMBh3roE42KcotLFtqp0RRwLtcBRNtCdsrVsjiI1Lqz/lH+T61sGjSjQ3CHMuZYSQJZo/KrvzgQXpkaCTdbObxHqb6/+i1qaVOfEsvjoiyzTxJADvSytVtcTjijhPEV6XskJVHE1Zgl+7rATr/pDQkw6DPCNBS1+Y6fy7GstZALQXwEDN/qhQI9kWkHijT8ns+i1vGg00Mk/6J75arLhqcodWsdeG/M/moWgqQAnlZAGVtJI1OgeF5fsPpXu4kctOfuZlGjVZXQNW34aOzm8r8S0eVZitPlbhcPiR4gT/aSMz/wd8lZlzZYsje/Jr8u/YtlwjjreZrGRmG8KMOzukV3lLmMppXFMvl4bxv6YFEmIuTsOhbLTwFgh7KYNjodLj/LsqRVfwz31PgWQFTEPICV7GCvgVlPRxnofqKSjgTWI4mxDhBpVcATvaoBl1L/6WLbFvBsoAUBItWwctO2xalKxF5szhGm8lccoc5MZr8kfE0uxMgsxz4er68iCID+rsCAQM=,
+      RemoteServerListUrl: https://s3.amazonaws.com//psiphon/web/mjr4-p23r-puwl/server_list_compressed,
+      SponsorId: FFFFFFFFFFFFFFFF,
+      UseIndistinguishableTLS: true
+    }
+  # Nonexistant local socks5 proxy
+  - configUrl: socks5://192.168.1.10:1080
+

--- a/x/smart/README.md
+++ b/x/smart/README.md
@@ -88,14 +88,14 @@ The fallback strings should be a valid StreamDialer configs as defined in https:
 
 ```yaml
 fallback:
-  - ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1
+  - configUrl: ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1
 ```
 
 #### SOCKS5 server example
 
 ```yaml
 fallback:
-  - socks5://[USERINFO]@[HOST]:[PORT]
+  - configUrl: socks5://[USERINFO]@[HOST]:[PORT]
 ```
 
 ### Using the Smart Dialer

--- a/x/smart/README.md
+++ b/x/smart/README.md
@@ -88,14 +88,14 @@ The fallback strings should be a valid StreamDialer configs as defined in https:
 
 ```yaml
 fallback:
-  - configUrl: ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1
+  - ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1
 ```
 
 #### SOCKS5 server example
 
 ```yaml
 fallback:
-  - configUrl: socks5://[USERINFO]@[HOST]:[PORT]
+  - socks5://[USERINFO]@[HOST]:[PORT]
 ```
 
 ### Using the Smart Dialer

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -15,6 +15,7 @@
 package smart
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -95,16 +96,41 @@ type dnsEntryConfig struct {
 	TCP    *tcpEntryConfig   `yaml:"tcp,omitempty"`
 }
 
-type fallbackEntryConfig struct {
-	ConfigURL 	string 					`yaml:"configUrl,omitempty"`
-	// Don't verify the psiphon config format here, just pass it forward
-	Psiphon 	map[string]interface{} 	`yaml:"psiphon,omitempty"`
+type fallbackEntryStructConfig struct {
+	Psiphon any	`yaml:"psiphon,omitempty"`
+	// As we allow more fallback types beyond psiphon they will be added here
 }
+
+// This contains either a configURL string or a fallbackEntryStructConfig
+// It is parsed into the correct type later
+type fallbackEntryConfig any
 
 type configConfig struct {
 	DNS      []dnsEntryConfig 		`yaml:"dns,omitempty"`
 	TLS      []string         		`yaml:"tls,omitempty"`
 	Fallback []fallbackEntryConfig 	`yaml:"fallback,omitempty"`
+}
+
+// mapToAny marshalls a map into a struct. It's a helper for parsers that want to
+// map config maps into their config structures.
+func mapToAny(in map[string]any, out any) error {
+	newMap := make(map[string]any)
+	for k, v := range in {
+		if len(k) > 0 && k[0] == '$' {
+			// Skip $ keys
+			continue
+		}
+		newMap[k] = v
+	}
+	yamlText, err := yaml.Marshal(newMap)
+	if err != nil {
+		return fmt.Errorf("error marshaling to YAML: %w", err)
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(yamlText), yaml.DisallowUnknownField())
+	if err := decoder.Decode(out); err != nil {
+		return fmt.Errorf("error decoding YAML: %w", err)
+	}
+	return nil
 }
 
 // newDNSResolverFromEntry creates a [dns.Resolver] based on the config, returning the resolver and
@@ -327,35 +353,39 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 	var configModule = configurl.NewDefaultProviders()
 
 	fallback, err := raceTests(ctx, 250*time.Millisecond, fallbackConfigs, func(fallbackConfig fallbackEntryConfig) (*SearchResult, error) {
-		if (fallbackConfig.Psiphon != nil) {
-			psiphonJSON, err := json.Marshal(fallbackConfig.Psiphon)
-			if err != nil {
-                f.logCtx(ctx, "Error marshaling to JSON: %v, %v", fallbackConfig.Psiphon, err)
-       		}
-
-			// TODO(laplante): pass this forward into psiphon.go, which takes raw json
-			f.logCtx(ctx, "❌ Psiphon is not yet supported, skipping: %v\n", string(psiphonJSON))
-			return nil, fmt.Errorf("psiphon is not yet supported: %v", string(psiphonJSON))
-		}
-
-		if (fallbackConfig.ConfigURL != "") {
-			fallbackUrl := fallbackConfig.ConfigURL
-			
-			dialer, err := configModule.NewStreamDialer(ctx, fallbackUrl)
+		switch v := fallbackConfig.(type) {
+		case string:
+			configUrl := v
+			dialer, err := configModule.NewStreamDialer(ctx, configUrl)
 			if err != nil {
 				return nil, fmt.Errorf("getStreamDialer failed: %w", err)
 			}
 
-			err = f.testDialer(ctx, dialer, testDomains, fallbackUrl)
+			err = f.testDialer(ctx, dialer, testDomains, configUrl)
 			if err != nil {
 				return nil, err
 			}
 
 			return &SearchResult{dialer, fallbackConfig}, nil
-		}
+		case fallbackEntryStructConfig:
+			if v.Psiphon != nil {
+				psiphonCfg := v.Psiphon
+				psiphonJSON, err := json.Marshal(psiphonCfg)
+				if err != nil {
+					f.logCtx(ctx, "Error marshaling to JSON: %v, %v", psiphonCfg, err)
+				}
 
-		return nil, fmt.Errorf("unknown fallback type: %v", fallbackConfig)
+				// TODO(laplante): pass this forward into psiphon.go, which takes raw json
+				f.logCtx(ctx, "❌ Psiphon is not yet supported, skipping: %v\n", string(psiphonJSON))
+				return nil, fmt.Errorf("psiphon is not yet supported: %v", string(psiphonJSON))
+			} else {
+				return nil, fmt.Errorf("unknown fallback type: %v", v)
+			}
+		default:
+			return nil, fmt.Errorf("unknown fallback type: %v", v)
+		}
 	})
+
 	if err != nil {
 		return nil, fmt.Errorf("could not find a working fallback: %w", err)
 	}
@@ -389,14 +419,46 @@ func (f *StrategyFinder) newProxylessDialer(ctx context.Context, testDomains []s
 	return f.findTLS(ctx, testDomains, dnsDialer, config.TLS)
 }
 
+func (f *StrategyFinder) parseConfig(configBytes []byte) (configConfig, error) {
+	var parsedConfig configConfig
+	var configMap map[string]any
+	err := yaml.Unmarshal(configBytes, &configMap)
+	if err != nil {
+		return configConfig{}, fmt.Errorf("failed to unmarshal config to map: %w", err)
+	}
+	err = mapToAny(configMap, &parsedConfig)
+	if err != nil {
+		return configConfig{}, fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	// Iterate through fallback field and convert individual elements to strings or fallbackEntryStructConfig
+	for i, fallbackElement := range parsedConfig.Fallback {
+		switch v := fallbackElement.(type) {
+		case string:
+			parsedConfig.Fallback[i] = v
+		case map[string]any:
+			var fallbackEntry fallbackEntryStructConfig
+			err := mapToAny(v, &fallbackEntry)
+			if err != nil {
+				return configConfig{}, fmt.Errorf("failed to parse fallback config: %w", err)
+			}
+			parsedConfig.Fallback[i] = fallbackEntry
+		default:
+			return configConfig{}, fmt.Errorf("unknown fallback type: %v", v)
+		}
+	}
+
+	return parsedConfig, nil
+}
+
 // NewDialer uses the config in configBytes to search for a strategy that unblocks DNS and TLS for all of the testDomains, returning a dialer with the found strategy.
 // It returns an error if no strategy was found that unblocks the testDomains.
 // The testDomains must be domains with a TLS service running on port 443.
 func (f *StrategyFinder) NewDialer(ctx context.Context, testDomains []string, configBytes []byte) (transport.StreamDialer, error) {
 	var parsedConfig configConfig
-	err := yaml.Unmarshal(configBytes, &parsedConfig)
+	parsedConfig, err := f.parseConfig(configBytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse config: %v", err)
+		return nil, err
 	}
 
 	// Make domain fully-qualified to prevent confusing domain search.

--- a/x/smart/stream_dialer_test.go
+++ b/x/smart/stream_dialer_test.go
@@ -1,0 +1,77 @@
+package smart
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfig_InvalidConfig(t *testing.T) {
+	config := `
+dns:
+  - randomkey: {}
+`
+	configBytes := []byte(config)
+	finder := &StrategyFinder{}
+	_, err := finder.parseConfig(configBytes)
+	require.Error(t, err)
+}
+
+func TestParseConfig_ValidConfig(t *testing.T) {
+	config := `
+dns:
+  - system: {}
+  - udp: { address: ns1.tic.ir }
+  - tcp: { address: ns1.tic.ir }
+  - udp: { address: tmcell.tm }
+  - udp: { address: dns1.transtelecom.net. }
+  - tls:
+      name: captive-portal.badssl.com
+      address: captive-portal.badssl.com:443
+  - https: { name: mitm-software.badssl.com }
+
+tls:
+  - ""
+  - split:1
+  - split:2
+  - split:5
+  - tlsfrag:1
+
+fallback:
+  - ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1
+  - psiphon: {
+      "PropagationChannelId":"FFFFFFFFFFFFFFFF",
+      "SponsorId":"FFFFFFFFFFFFFFFF",
+    }
+  - socks5://192.168.1.10:1080
+`
+	configBytes := []byte(config)
+	finder := &StrategyFinder{}
+	parsedConfig, err := finder.parseConfig(configBytes)
+	require.NoError(t, err)
+
+	expectedConfig := configConfig{
+		DNS: []dnsEntryConfig{
+			{System: &struct{}{}},
+			{UDP: &udpEntryConfig{Address: "ns1.tic.ir"}},
+			{TCP: &tcpEntryConfig{Address: "ns1.tic.ir"}},
+			{UDP: &udpEntryConfig{Address: "tmcell.tm"}},
+			{UDP: &udpEntryConfig{Address: "dns1.transtelecom.net."}},
+			{TLS: &tlsEntryConfig{Name: "captive-portal.badssl.com", Address: "captive-portal.badssl.com:443"}},
+			{HTTPS: &httpsEntryConfig{Name: "mitm-software.badssl.com"}},
+		},
+		TLS: []string{"", "split:1", "split:2", "split:5", "tlsfrag:1"},
+		Fallback: []fallbackEntryConfig{
+			"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1",
+			fallbackEntryStructConfig{
+				Psiphon: map[string]any {
+					"PropagationChannelId": "FFFFFFFFFFFFFFFF",
+					"SponsorId":            "FFFFFFFFFFFFFFFF",
+				},
+			},
+			"socks5://192.168.1.10:1080",
+		},
+	}
+
+	require.Equal(t, expectedConfig, parsedConfig)
+}


### PR DESCRIPTION
This is not yet setting up the psiphon connection, but I figured it would be important to hash out exactly what format we want to use in `config.yaml` for the fallbacks since this is modifying the format slightly from https://github.com/Jigsaw-Code/outline-sdk/pull/384.

I've broken the parsing of the config out into `parseConfig` to deal with the string and object parsing.

Don't worry too much about the json parsing/logging around :331. It will go away in the next PR. I just wanted to make sure this parsing approach would work for getting from YAML->rawJson without actually putting the format validation here.

### Tested

```
go run -C ./x/examples/smart-proxy/ . -v -localAddr=localhost:1080 --transport="" --domain rt.com  --config=[...]/outline-sdk/x/examples/smart-proxy/config_broken.yaml
Finding strategy
...
[DNS/TLS output omitted]
...
🏃 running test: 'ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1' (domain: rt.com.)
❌ Psiphon is not yet supported, skipping: {"psiphon":{"LocalHttpProxyPort":8081,"LocalSocksProxyPort":1081,"PropagationChannelId":"FFFFFFFFFFFFFFFF","RemoteServerListDownloadFilename":"remote_server_list","RemoteServerListSignaturePublicKey":"MIICIDANBgkqhkiG9w0BAQEFAAOCAg0AMIICCAKCAgEAt7Ls+/39r+T6zNW7GiVpJfzq/xvL9SBH5rIFnk0RXYEYavax3WS6HOD35eTAqn8AniOwiH+DOkvgSKF2caqk/y1dfq47Pdymtwzp9ikpB1C5OfAysXzBiwVJlCdajBKvBZDerV1cMvRzCKvKwRmvDmHgphQQ7WfXIGbRbmmk6opMBh3roE42KcotLFtqp0RRwLtcBRNtCdsrVsjiI1Lqz/lH+T61sGjSjQ3CHMuZYSQJZo/KrvzgQXpkaCTdbObxHqb6/+i1qaVOfEsvjoiyzTxJADvSytVtcTjijhPEV6XskJVHE1Zgl+7rATr/pDQkw6DPCNBS1+Y6fy7GstZALQXwEDN/qhQI9kWkHijT8ns+i1vGg00Mk/6J75arLhqcodWsdeG/M/moWgqQAnlZAGVtJI1OgeF5fsPpXu4kctOfuZlGjVZXQNW34aOzm8r8S0eVZitPlbhcPiR4gT/aSMz/wd8lZlzZYsje/Jr8u/YtlwjjreZrGRmG8KMOzukV3lLmMppXFMvl4bxv6YFEmIuTsOhbLTwFgh7KYNjodLj/LsqRVfwz31PgWQFTEPICV7GCvgVlPRxnofqKSjgTWI4mxDhBpVcATvaoBl1L/6WLbFvBsoAUBItWwctO2xalKxF5szhGm8lccoc5MZr8kfE0uxMgsxz4er68iCID+rsCAQM=","RemoteServerListUrl":"https://s3.amazonaws.com//psiphon/web/mjr4-p23r-puwl/server_list_compressed","SponsorId":"FFFFFFFFFFFFFFFF","UseIndistinguishableTLS":true}}
🏃 running test: 'socks5://192.168.1.10:1080' (domain: rt.com.)
2025/03/25 17:08:00 Failed to find dialer: could not find a working fallback: all tests failed
exit status 1
```

Also tested a failing psiphon config followed by a successful outline server.