### PR TITLE
feat(x) explicit timeout in psiphon-fetch start

### DIFF
--- a/x/examples/fetch-psiphon/main.go
+++ b/x/examples/fetch-psiphon/main.go
@@ -80,7 +80,9 @@ func main() {
 
 	// Start the Psiphon dialer.
 	dialer := psiphon.GetSingletonDialer()
-	if err := dialer.Start(context.Background(), config); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 30 * time.Second)
+	defer cancel()
+	if err := dialer.Start(ctx, config); err != nil {
 		log.Fatalf("Could not start dialer: %v\n", err)
 	}
 	defer dialer.Stop()


### PR DESCRIPTION
Currently the psiphon-fetch start defaults to psiphon's internal 5m start timeout, which seems too long. For any invalid but valid-enough (meaning containing any `PropagationChannelId`+`SponsorId`) config it hangs for a long time.

I'm not particularly married to the 30s

## Current behavior

running

`go run -C ./examples/fetch-psiphon -tags psiphon . -config minimal_config.json -v https://ipinfo.io`

Where the content of `minimal_config.json` is

` { "PropagationChannelId":"ID1", "SponsorId":"ID2" } `

hangs for 5 minutes before failing with the error

`Could not start dialer: clientlib: tunnel establishment timeout` [error link](https://github.com/Psiphon-Labs/psiphon-tunnel-core/blob/0ef1e60c258622c09d1750b6e29e0d36002e2316/ClientLibrary/clientlib/clientlib.go#L108)


## After this change

It fails in 30s