### PR TITLE
feat(x) create the psiphon dialer in smart-proxy

### DIFF
--- a/x/examples/smart-proxy/config_broken.yaml
+++ b/x/examples/smart-proxy/config_broken.yaml
@@ -32,6 +32,8 @@ fallback:
       "DisableLocalSocksProxy" : true,
       "DisableLocalHTTPProxy" : true,
       "EstablishTunnelTimeoutSeconds": 1,
+      # URL points to google.com
+      "RemoteServerListURLs" : [{"URL": "aHR0cHM6Ly9nb29nbGUuY29t", "OnlyAfterAttempts": 0, "SkipVerify": false}],
     }
   # Nonexistant local socks5 proxy
   - socks5://192.168.1.10:1080

--- a/x/examples/smart-proxy/config_broken.yaml
+++ b/x/examples/smart-proxy/config_broken.yaml
@@ -25,10 +25,13 @@ tls:
 fallback:
   # Nonexistent Outline Server
   - ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1
-  # Nonexistant Psiphon Config JSON. Not yet supported
+  # Nonexistant Psiphon Config JSON
   - psiphon: {
-      "PropagationChannelId":"FFFFFFFFFFFFFFFF",
-      "SponsorId":"FFFFFFFFFFFFFFFF",
+      "PropagationChannelId":"ID1",
+      "SponsorId":"ID2",
+      "DisableLocalSocksProxy" : true,
+      "DisableLocalHTTPProxy" : true,
+      "EstablishTunnelTimeoutSeconds": 1,
     }
   # Nonexistant local socks5 proxy
   - socks5://192.168.1.10:1080

--- a/x/examples/smart-proxy/main.go
+++ b/x/examples/smart-proxy/main.go
@@ -83,17 +83,17 @@ func main() {
 
 	finderConfig, err := os.ReadFile(*configFlag)
 	if err != nil {
-		log.Fatalf("Could not read config: %v\n", err)
+		log.Fatalf("Could not read config: %v", err)
 	}
 
 	providers := configurl.NewDefaultProviders()
 	packetDialer, err := providers.NewPacketDialer(context.Background(), *transportFlag)
 	if err != nil {
-		log.Fatalf("Could not create packet dialer: %v\n", err)
+		log.Fatalf("Could not create packet dialer: %v", err)
 	}
 	streamDialer, err := providers.NewStreamDialer(context.Background(), *transportFlag)
 	if err != nil {
-		log.Fatalf("Could not create stream dialer: %v\n", err)
+		log.Fatalf("Could not create stream dialer: %v", err)
 	}
 	if !supportsHappyEyeballs(streamDialer) {
 		fmt.Println("⚠️ Warning: base transport is not compatible with Happy Eyeballs. Disabling IPv6.")
@@ -124,7 +124,7 @@ func main() {
 
 	dialer, err := finder.NewDialer(findCtx, domainsFlag, finderConfig)
 	if err != nil {
-		log.Fatalf("Failed to find dialer: %v\n", err)
+		log.Fatalf("Failed to find dialer: %v", err)
 	}
 	fmt.Printf("Found strategy in %0.2fs\n", time.Since(startTime).Seconds())
 	logDialer := transport.FuncStreamDialer(func(ctx context.Context, address string) (transport.StreamConn, error) {
@@ -137,7 +137,7 @@ func main() {
 
 	listener, err := net.Listen("tcp", *addrFlag)
 	if err != nil {
-		log.Fatalf("Could not listen on address %v: %v\n", *addrFlag, err)
+		log.Fatalf("Could not listen on address %v: %v", *addrFlag, err)
 	}
 	defer listener.Close()
 	fmt.Printf("Proxy listening on %v\n", listener.Addr().String())
@@ -148,7 +148,7 @@ func main() {
 	}
 	go func() {
 		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("Error running web server: %v\n", err)
+			log.Fatalf("Error running web server: %v", err)
 		}
 	}()
 
@@ -161,6 +161,6 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := server.Shutdown(ctx); err != nil {
-		log.Fatalf("Failed to shutdown gracefully: %v\n", err)
+		log.Fatalf("Failed to shutdown gracefully: %v", err)
 	}
 }

--- a/x/examples/smart-proxy/main.go
+++ b/x/examples/smart-proxy/main.go
@@ -83,17 +83,17 @@ func main() {
 
 	finderConfig, err := os.ReadFile(*configFlag)
 	if err != nil {
-		log.Fatalf("Could not read config: %v", err)
+		log.Fatalf("Could not read config: %v\n", err)
 	}
 
 	providers := configurl.NewDefaultProviders()
 	packetDialer, err := providers.NewPacketDialer(context.Background(), *transportFlag)
 	if err != nil {
-		log.Fatalf("Could not create packet dialer: %v", err)
+		log.Fatalf("Could not create packet dialer: %v\n", err)
 	}
 	streamDialer, err := providers.NewStreamDialer(context.Background(), *transportFlag)
 	if err != nil {
-		log.Fatalf("Could not create stream dialer: %v", err)
+		log.Fatalf("Could not create stream dialer: %v\n", err)
 	}
 	if !supportsHappyEyeballs(streamDialer) {
 		fmt.Println("⚠️ Warning: base transport is not compatible with Happy Eyeballs. Disabling IPv6.")
@@ -121,7 +121,7 @@ func main() {
 	startTime := time.Now()
 	dialer, err := finder.NewDialer(context.Background(), domainsFlag, finderConfig)
 	if err != nil {
-		log.Fatalf("Failed to find dialer: %v", err)
+		log.Fatalf("Failed to find dialer: %v\n", err)
 	}
 	fmt.Printf("Found strategy in %0.2fs\n", time.Since(startTime).Seconds())
 	logDialer := transport.FuncStreamDialer(func(ctx context.Context, address string) (transport.StreamConn, error) {
@@ -134,7 +134,7 @@ func main() {
 
 	listener, err := net.Listen("tcp", *addrFlag)
 	if err != nil {
-		log.Fatalf("Could not listen on address %v: %v", *addrFlag, err)
+		log.Fatalf("Could not listen on address %v: %v\n", *addrFlag, err)
 	}
 	defer listener.Close()
 	fmt.Printf("Proxy listening on %v\n", listener.Addr().String())
@@ -145,7 +145,7 @@ func main() {
 	}
 	go func() {
 		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("Error running web server: %v", err)
+			log.Fatalf("Error running web server: %v\n", err)
 		}
 	}()
 
@@ -158,6 +158,6 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := server.Shutdown(ctx); err != nil {
-		log.Fatalf("Failed to shutdown gracefully: %v", err)
+		log.Fatalf("Failed to shutdown gracefully: %v\n", err)
 	}
 }

--- a/x/examples/smart-proxy/main.go
+++ b/x/examples/smart-proxy/main.go
@@ -119,7 +119,7 @@ func main() {
 
 	fmt.Println("Finding strategy")
 	startTime := time.Now()
-	findCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	findCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	dialer, err := finder.NewDialer(findCtx, domainsFlag, finderConfig)

--- a/x/examples/smart-proxy/main.go
+++ b/x/examples/smart-proxy/main.go
@@ -119,7 +119,10 @@ func main() {
 
 	fmt.Println("Finding strategy")
 	startTime := time.Now()
-	dialer, err := finder.NewDialer(context.Background(), domainsFlag, finderConfig)
+	findCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	dialer, err := finder.NewDialer(findCtx, domainsFlag, finderConfig)
 	if err != nil {
 		log.Fatalf("Failed to find dialer: %v\n", err)
 	}

--- a/x/mobileproxy/README.md
+++ b/x/mobileproxy/README.md
@@ -34,6 +34,13 @@ From the `x/` directory:
 go build -o "$(pwd)/out/" golang.org/x/mobile/cmd/gomobile golang.org/x/mobile/cmd/gobind
 ```
 
+> [!WARNING]
+> The psiphon library is not included in the build by default because the psiphon codebase uses GPL. To support psiphon configuration in smart-proxy please build using the `psiphon` build tag.
+
+```bash
+go build -tags psiphon -o "$(pwd)/out/" golang.org/x/mobile/cmd/gomobile golang.org/x/mobile/cmd/gobind
+```
+
 Then build the iOS and Android libraries with [`gomobile bind`](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile#hdr-Build_a_library_for_Android_and_iOS)
 
 ```bash

--- a/x/mobileproxy/README.md
+++ b/x/mobileproxy/README.md
@@ -35,7 +35,8 @@ go build -o "$(pwd)/out/" golang.org/x/mobile/cmd/gomobile golang.org/x/mobile/c
 ```
 
 > [!WARNING]
-> The psiphon library is not included in the build by default because the psiphon codebase uses GPL. To support psiphon configuration in smart-proxy please build using the `psiphon` build tag.
+> The Psiphon library is not included in the build by default because the Psiphon codebase uses GPL. To support Psiphon configuration in the Mobile Proxy please build using the [`psiphon` build tag](https://pkg.go.dev/github.com/Jigsaw-Code/outline-sdk/x/psiphon).
+> When integrating Psiphon into your application please work with the Psiphon team at sponsor@psiphon.ca
 
 ```bash
 go build -tags psiphon -o "$(pwd)/out/" golang.org/x/mobile/cmd/gomobile golang.org/x/mobile/cmd/gobind

--- a/x/psiphon/doc.go
+++ b/x/psiphon/doc.go
@@ -26,8 +26,7 @@ For testing, you can [generate a Psiphon config yourself].
 Psiphon code is licensed as GPLv3, which you will have to take into account if you incorporate Psiphon logic into your app.
 If you don't want your app to be GPL, consider acquiring an appropriate license when acquiring their services.
 
-Note that a few of Psiphon's dependencies may impose additional restrictions. For example, github.com/hashicorp/golang-lru is MPL-2.0
-and github.com/juju/ratelimit is LGPL-3.0. You can use [go-licenses] to analyze the licenses of your Go code dependencies.
+Note that a few of Psiphon's dependencies may impose additional restrictions. You can use [go-licenses] to analyze the licenses of your Go code dependencies.
 
 To prevent accidental inclusion of unvetted licenses, you must use the "psiphon" build tag in order to use this package. Typically you do that with
 "-tags psiphon".

--- a/x/smart/README.md
+++ b/x/smart/README.md
@@ -121,8 +121,6 @@ fallback:
       "SponsorId": "FFFFFFFFFFFFFFFF",
       "DisableLocalSocksProxy" : true,
       "DisableLocalHTTPProxy" : true,
-      # It's important to include an explicit timeout, otherwise an invalid connection will hang for a long time
-      "EstablishTunnelTimeoutSeconds": 5,
       ...
     }
 ```

--- a/x/smart/README.md
+++ b/x/smart/README.md
@@ -85,7 +85,7 @@ A fallback configuration is used if none of the proxyless strategies are able to
 The fallback strings should be:
 
 *   A valid StreamDialer config string as defined in [configurl](https://pkg.go.dev/github.com/Jigsaw-Code/outline-sdk/x/configurl#hdr-Proxy_Protocols)
-*   A valid psiphon configuration.
+*   A valid Psiphon configuration.
 
 #### Shadowsocks server example
 
@@ -104,7 +104,8 @@ fallback:
 #### Psiphon config example
 
 > [!WARNING]
-> The psiphon library is not included in the build by default because the psiphon codebase uses GPL. To support psiphon configuration please build using the `psiphon` build tag.
+> The Psiphon library is not included in the build by default because the Psiphon codebase uses GPL. To support Psiphon configuration please build using the [`psiphon` build tag](https://pkg.go.dev/github.com/Jigsaw-Code/outline-sdk/x/psiphon).
+> When integrating Psiphon into your application please work with the Psiphon team at sponsor@psiphon.ca
 
 JSON is a subset of YAML. If you have an existing psiphon JSON configuration file you can simply copy-and-paste it into your smart-proxy config.yaml file like so:
 
@@ -121,7 +122,8 @@ fallback:
       "DisableLocalSocksProxy" : true,
       "DisableLocalHTTPProxy" : true,
       # It's important to include an explicit timeout, otherwise an invalid connection will hang for a long time
-      "EstablishTunnelTimeoutSeconds": 5, 
+      "EstablishTunnelTimeoutSeconds": 5,
+      ...
     }
 ```
 

--- a/x/smart/README.md
+++ b/x/smart/README.md
@@ -85,7 +85,7 @@ A fallback configuration is used if none of the proxyless strategies are able to
 The fallback strings should be:
 
 *   A valid StreamDialer config string as defined in [configurl](https://pkg.go.dev/github.com/Jigsaw-Code/outline-sdk/x/configurl#hdr-Proxy_Protocols)
-*   A valid Psiphon configuration.
+*   A valid Psiphon configuration object as a child of a `psiphon` field.
 
 #### Shadowsocks server example
 

--- a/x/smart/README.md
+++ b/x/smart/README.md
@@ -82,7 +82,10 @@ tcp:
 
 A fallback configuration is used if none of the proxyless strategies are able to connect. For example it can specify a backup proxy server to attempt the user's connection. Using a fallback will be slower to start, since first the other DNS/TLS strategies must fail/timeout.
 
-The fallback strings should be a valid StreamDialer configs as defined in https://pkg.go.dev/github.com/Jigsaw-Code/outline-sdk/x/configurl#hdr-Proxy_Protocols
+The fallback strings should be:
+
+*   A valid StreamDialer config string as defined in [configurl](https://pkg.go.dev/github.com/Jigsaw-Code/outline-sdk/x/configurl#hdr-Proxy_Protocols)
+*   A valid psiphon configuration.
 
 #### Shadowsocks server example
 
@@ -96,6 +99,30 @@ fallback:
 ```yaml
 fallback:
   - socks5://[USERINFO]@[HOST]:[PORT]
+```
+
+#### Psiphon config example
+
+> [!WARNING]
+> The psiphon library is not included in the build by default because the psiphon codebase uses GPL. To support psiphon configuration please build using the `psiphon` build tag.
+
+JSON is a subset of YAML. If you have an existing psiphon JSON configuration file you can simply copy-and-paste it into your smart-proxy config.yaml file like so:
+
+```yaml
+fallback:
+  - psiphon: <YOUR_PSIPHON_CONFIG_HERE>
+```
+
+```yaml
+fallback:
+  - psiphon: {
+      "PropagationChannelId": "FFFFFFFFFFFFFFFF",
+      "SponsorId": "FFFFFFFFFFFFFFFF",
+      "DisableLocalSocksProxy" : true,
+      "DisableLocalHTTPProxy" : true,
+      # It's important to include an explicit timeout, otherwise an invalid connection will hang for a long time
+      "EstablishTunnelTimeoutSeconds": 5, 
+    }
 ```
 
 ### Using the Smart Dialer

--- a/x/smart/psiphon_dialer.go
+++ b/x/smart/psiphon_dialer.go
@@ -5,19 +5,35 @@ package smart
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"os"
+	"path"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/Jigsaw-Code/outline-sdk/x/psiphon"
 )
 
-func newPsiphonDialer(ctx context.Context, psiphonJSON []byte) (transport.StreamDialer, error) {
-	// Test calling psiphon package to prove it works
+func newPsiphonDialer(ctx context.Context, psiphonJSON []byte, psiphonSignature string) (transport.StreamDialer, error) {
+	config := &psiphon.DialerConfig{ProviderConfig: psiphonJSON}
+
+	cacheBaseDir, err := os.UserCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get the user cache directory: %w", err)
+	}
+
+	config.DataRootDirectory = path.Join(cacheBaseDir, "psiphon")
+	if err := os.MkdirAll(config.DataRootDirectory, 0700); err != nil {
+		return nil, fmt.Errorf("Failed to create storage directory: %w", err)
+	}
+	fmt.Printf("Using data store in %v\n", config.DataRootDirectory)
+
 	dialer := psiphon.GetSingletonDialer()
-	fmt.Printf("Initializing psiphon dialer: %+v\n", dialer)
+	// The psiphon singleton persists in the background across connections
+	ctx = context.WithoutCancel(ctx)
+	fmt.Printf("🏃 Attempting to start psiphon tunnel: %v\n", psiphonSignature)
+	if err := dialer.Start(ctx, config); err != nil {
+		return nil, fmt.Errorf("failed to start psiphon dialer: %w", err)
+	}
 
-	//TODO(laplante): set up and use psiphon dialer
-
-	return nil, fmt.Errorf("psiphon is not yet supported, skipping: %w", errors.ErrUnsupported) 
+	return dialer, nil
 }

--- a/x/smart/psiphon_dialer.go
+++ b/x/smart/psiphon_dialer.go
@@ -1,4 +1,6 @@
+//go:build psiphon
 // +build psiphon
+
 // If the build tag `psiphon` is set, allow importing and calling psiphon
 
 package smart
@@ -13,7 +15,7 @@ import (
 	"github.com/Jigsaw-Code/outline-sdk/x/psiphon"
 )
 
-func newPsiphonDialer(ctx context.Context, psiphonJSON []byte, psiphonSignature string) (transport.StreamDialer, error) {
+func newPsiphonDialer(finder *StrategyFinder, ctx context.Context, psiphonJSON []byte, psiphonSignature string) (transport.StreamDialer, error) {
 	config := &psiphon.DialerConfig{ProviderConfig: psiphonJSON}
 
 	cacheBaseDir, err := os.UserCacheDir()
@@ -25,10 +27,10 @@ func newPsiphonDialer(ctx context.Context, psiphonJSON []byte, psiphonSignature 
 	if err := os.MkdirAll(config.DataRootDirectory, 0700); err != nil {
 		return nil, fmt.Errorf("Failed to create storage directory: %w", err)
 	}
-	fmt.Printf("Using data store in %v\n", config.DataRootDirectory)
+	finder.logCtx(ctx, "Using data store in %v\n", config.DataRootDirectory)
 
 	dialer := psiphon.GetSingletonDialer()
-	fmt.Printf("🏃 Attempting to start psiphon tunnel: %v\n", psiphonSignature)
+	finder.logCtx(ctx, "🏃 Attempting to start psiphon tunnel: %v\n", psiphonSignature)
 	if err := dialer.Start(ctx, config); err != nil {
 		return nil, fmt.Errorf("failed to start psiphon dialer: %w", err)
 	}

--- a/x/smart/psiphon_dialer.go
+++ b/x/smart/psiphon_dialer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Jigsaw-Code/outline-sdk/x/psiphon"
 )
 
-func newPsiphonDialer(finder *StrategyFinder, ctx context.Context, psiphonJSON []byte, psiphonSignature string) (transport.StreamDialer, error) {
+func newPsiphonDialer(finder *StrategyFinder, ctx context.Context, psiphonJSON []byte) (transport.StreamDialer, error) {
 	config := &psiphon.DialerConfig{ProviderConfig: psiphonJSON}
 
 	cacheBaseDir, err := os.UserCacheDir()
@@ -30,7 +30,6 @@ func newPsiphonDialer(finder *StrategyFinder, ctx context.Context, psiphonJSON [
 	finder.logCtx(ctx, "Using data store in %v\n", config.DataRootDirectory)
 
 	dialer := psiphon.GetSingletonDialer()
-	finder.logCtx(ctx, "🏃 Attempting to start psiphon tunnel: %v\n", psiphonSignature)
 	if err := dialer.Start(ctx, config); err != nil {
 		return nil, fmt.Errorf("failed to start psiphon dialer: %w", err)
 	}

--- a/x/smart/psiphon_dialer.go
+++ b/x/smart/psiphon_dialer.go
@@ -28,8 +28,6 @@ func newPsiphonDialer(ctx context.Context, psiphonJSON []byte, psiphonSignature 
 	fmt.Printf("Using data store in %v\n", config.DataRootDirectory)
 
 	dialer := psiphon.GetSingletonDialer()
-	// The psiphon singleton persists in the background across connections
-	ctx = context.WithoutCancel(ctx)
 	fmt.Printf("🏃 Attempting to start psiphon tunnel: %v\n", psiphonSignature)
 	if err := dialer.Start(ctx, config); err != nil {
 		return nil, fmt.Errorf("failed to start psiphon dialer: %w", err)

--- a/x/smart/psiphon_dialer_unimplemented.go
+++ b/x/smart/psiphon_dialer_unimplemented.go
@@ -1,4 +1,5 @@
 //go:build !psiphon
+
 // If the build tag `psiphon` is not set, create a stub function to avoid pulling in GPL'd code
 
 package smart
@@ -11,8 +12,8 @@ import (
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 )
 
-func newPsiphonDialer(ctx context.Context, psiphonJSON []byte, psiphonSignature string) (transport.StreamDialer, error) {
-	fmt.Printf("❌ Attempted to start psiphon tunnel %v but library was built without psiphon support. Please build using -tag psiphon.\n", psiphonSignature)
+func newPsiphonDialer(finder *StrategyFinder, ctx context.Context, psiphonJSON []byte, psiphonSignature string) (transport.StreamDialer, error) {
+	finder.logCtx(ctx, "❌ Attempted to start psiphon tunnel %v but library was built without psiphon support. Please build using -tag psiphon.\n", psiphonSignature)
 
-	return nil, fmt.Errorf("To use psiphon configuration in x/smart the package must be built with the build tag `psiphon`: %w", errors.ErrUnsupported)
+	return nil, fmt.Errorf("to use psiphon configuration in x/smart the package must be built with the build tag `psiphon`: %w", errors.ErrUnsupported)
 }

--- a/x/smart/psiphon_dialer_unimplemented.go
+++ b/x/smart/psiphon_dialer_unimplemented.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 )
 
-func newPsiphonDialer(ctx context.Context, psiphonJSON []byte) (transport.StreamDialer, error) {
-	return nil, fmt.Errorf("To use psiphon configuration in x/smart the package must be built with the build tag `psiphon`: %w", errors.ErrUnsupported) 
+func newPsiphonDialer(ctx context.Context, psiphonJSON []byte, psiphonSignature string) (transport.StreamDialer, error) {
+	fmt.Printf("❌ Attempted to start psiphon tunnel %v but library was built without psiphon support. Please build using -tag psiphon.\n", psiphonSignature)
+
+	return nil, fmt.Errorf("To use psiphon configuration in x/smart the package must be built with the build tag `psiphon`: %w", errors.ErrUnsupported)
 }

--- a/x/smart/psiphon_dialer_unimplemented.go
+++ b/x/smart/psiphon_dialer_unimplemented.go
@@ -12,8 +12,6 @@ import (
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 )
 
-func newPsiphonDialer(finder *StrategyFinder, ctx context.Context, psiphonJSON []byte, psiphonSignature string) (transport.StreamDialer, error) {
-	finder.logCtx(ctx, "❌ Attempted to start psiphon tunnel %v but library was built without psiphon support. Please build using -tag psiphon.\n", psiphonSignature)
-
-	return nil, fmt.Errorf("to use psiphon configuration in x/smart the package must be built with the build tag `psiphon`: %w", errors.ErrUnsupported)
+func newPsiphonDialer(_ *StrategyFinder, _ context.Context, _ []byte) (transport.StreamDialer, error) {
+	return nil, fmt.Errorf("attempted to start psiphon tunnel but library was built without psiphon support. Please build using -tag psiphon: %w", errors.ErrUnsupported)
 }

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -27,10 +27,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/goccy/go-yaml"
 	"github.com/Jigsaw-Code/outline-sdk/dns"
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
+	"github.com/goccy/go-yaml"
 )
 
 // To test one strategy:
@@ -97,7 +97,7 @@ type dnsEntryConfig struct {
 }
 
 type fallbackEntryStructConfig struct {
-	Psiphon any	`yaml:"psiphon,omitempty"`
+	Psiphon any `yaml:"psiphon,omitempty"`
 	// As we allow more fallback types beyond psiphon they will be added here
 }
 
@@ -106,9 +106,9 @@ type fallbackEntryStructConfig struct {
 type fallbackEntryConfig any
 
 type configConfig struct {
-	DNS      []dnsEntryConfig 		`yaml:"dns,omitempty"`
-	TLS      []string         		`yaml:"tls,omitempty"`
-	Fallback []fallbackEntryConfig 	`yaml:"fallback,omitempty"`
+	DNS      []dnsEntryConfig      `yaml:"dns,omitempty"`
+	TLS      []string              `yaml:"tls,omitempty"`
+	Fallback []fallbackEntryConfig `yaml:"fallback,omitempty"`
 }
 
 // mapToAny marshalls a map into a struct. It's a helper for parsers that want to
@@ -397,7 +397,7 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 				}
 				psiphonSignature := f.getPsiphonConfigSignature(psiphonJSON)
 
-				dialer, err := newPsiphonDialer(ctx, psiphonJSON, psiphonSignature)
+				dialer, err := newPsiphonDialer(f, ctx, psiphonJSON, psiphonSignature)
 				if err != nil {
 					return nil, fmt.Errorf("getPsiphonDialer failed: %w", err)
 				}
@@ -412,7 +412,7 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 				return nil, fmt.Errorf("unknown fallback type: %v", v)
 			}
 		default:
-			return nil, fmt.Errorf("unknown fallback type: %v\n", v)
+			return nil, fmt.Errorf("unknown fallback type: %v", v)
 		}
 	})
 

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -393,7 +393,7 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 				psiphonCfg := v.Psiphon
 				psiphonJSON, err := json.Marshal(psiphonCfg)
 				if err != nil {
-					f.logCtx(ctx, "Error marshaling to JSON: %v, %v", psiphonCfg, err)
+					f.logCtx(ctx, "Error marshaling to JSON: %v, %v\n", psiphonCfg, err)
 				}
 				psiphonSignature := f.getPsiphonConfigSignature(psiphonJSON)
 
@@ -404,7 +404,7 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 
 				err = f.testDialer(raceCtx, dialer, testDomains, psiphonSignature)
 				if err != nil {
-					f.logCtx(ctx, "error testing dialer: %v, %v", psiphonSignature, err)
+					f.logCtx(ctx, "error testing dialer: %v, %v\n", psiphonSignature, err)
 					return nil, err
 				}
 
@@ -413,7 +413,7 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 				return nil, fmt.Errorf("unknown fallback type: %v", v)
 			}
 		default:
-			return nil, fmt.Errorf("unknown fallback type: %v", v)
+			return nil, fmt.Errorf("unknown fallback type: %v\n", v)
 		}
 	})
 

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -196,7 +196,7 @@ func (f *StrategyFinder) newDNSResolverFromEntry(entry dnsEntryConfig) (dns.Reso
 // Takes a (potentially very long) psiphon config and outputs
 // a short signature string for logging identification purposes
 // with only the PropagationChannelId and SponsorId (required fields)
-// ex: {PropagationChannelId: FFFFFFFFFFFFFFFF, SponsorId: FFFFFFFFFFFFFFFF}
+// ex: {PropagationChannelId: FFFFFFFFFFFFFFFF, SponsorId: FFFFFFFFFFFFFFFF, [...]}
 // If the config does not contains these fields
 // output the whole config as a string
 func (f *StrategyFinder) getPsiphonConfigSignature(psiphonJSON []byte) string {
@@ -209,7 +209,7 @@ func (f *StrategyFinder) getPsiphonConfigSignature(psiphonJSON []byte) string {
 	sponsorId, ok2 := psiphonConfig["SponsorId"].(string)
 
 	if ok1 && ok2 {
-		return fmt.Sprintf("Psiphon: {PropagationChannelId: %v, SponsorId: %v}", propagationChannelId, sponsorId)
+		return fmt.Sprintf("Psiphon: {PropagationChannelId: %v, SponsorId: %v, [...]}", propagationChannelId, sponsorId)
 	}
 	return string(psiphonJSON)
 }

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -209,7 +209,7 @@ func (f *StrategyFinder) getPsiphonConfigSignature(psiphonJSON []byte) string {
 	sponsorId, ok2 := psiphonConfig["SponsorId"].(string)
 
 	if ok1 && ok2 {
-		return fmt.Sprintf("{PropagationChannelId: %v, SponsorId: %v}", propagationChannelId, sponsorId)
+		return fmt.Sprintf("Psiphon: {PropagationChannelId: %v, SponsorId: %v}", propagationChannelId, sponsorId)
 	}
 	return string(psiphonJSON)
 }

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -404,7 +404,6 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 
 				err = f.testDialer(raceCtx, dialer, testDomains, psiphonSignature)
 				if err != nil {
-					f.logCtx(ctx, "error testing dialer: %v, %v\n", psiphonSignature, err)
 					return nil, err
 				}
 

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -428,9 +428,9 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 	fallback, err := raceTests(raceCtx, 250*time.Millisecond, fallbackConfigs, func(fallbackConfig fallbackEntryConfig) (*SearchResult, error) {
 		configSignature := f.getConfigSignature(fallbackConfig)
 
-		dialer, err := f.makeDialerFromConfig(ctx, configModule, fallbackConfig)
+		dialer, err := f.makeDialerFromConfig(raceCtx, configModule, fallbackConfig)
 		if err != nil {
-			f.logCtx(ctx, "❌ Failed to start dialer: %v %v\n", configSignature, err)
+			f.logCtx(raceCtx, "❌ Failed to start dialer: %v %v\n", configSignature, err)
 			return nil, err
 		}
 

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -193,6 +193,27 @@ func (f *StrategyFinder) newDNSResolverFromEntry(entry dnsEntryConfig) (dns.Reso
 	}
 }
 
+// Takes a (potentially very long) psiphon config and outputs
+// a short signature string for logging identification purposes
+// with only the PropagationChannelId and SponsorId (required fields)
+// ex: {PropagationChannelId: FFFFFFFFFFFFFFFF, SponsorId: FFFFFFFFFFFFFFFF}
+// If the config does not contains these fields
+// output the whole config as a string
+func (f *StrategyFinder) getPsiphonConfigSignature(psiphonJSON []byte) string {
+	var psiphonConfig map[string]any
+	if err := json.Unmarshal(psiphonJSON, &psiphonConfig); err != nil {
+		return string(psiphonJSON)
+	}
+
+	propagationChannelId, ok1 := psiphonConfig["PropagationChannelId"].(string)
+	sponsorId, ok2 := psiphonConfig["SponsorId"].(string)
+
+	if ok1 && ok2 {
+		return fmt.Sprintf("{PropagationChannelId: %v, SponsorId: %v}", propagationChannelId, sponsorId)
+	}
+	return string(psiphonJSON)
+}
+
 type smartResolver struct {
 	dns.Resolver
 	ID     string
@@ -343,7 +364,7 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 		return nil, errors.New("attempted to find fallback but no fallback configuration was specified")
 	}
 
-	ctx, searchDone := context.WithCancel(ctx)
+	raceCtx, searchDone := context.WithCancel(ctx)
 	defer searchDone()
 	raceStart := time.Now()
 	type SearchResult struct {
@@ -352,16 +373,16 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 	}
 	var configModule = configurl.NewDefaultProviders()
 
-	fallback, err := raceTests(ctx, 250*time.Millisecond, fallbackConfigs, func(fallbackConfig fallbackEntryConfig) (*SearchResult, error) {
+	fallback, err := raceTests(raceCtx, 250*time.Millisecond, fallbackConfigs, func(fallbackConfig fallbackEntryConfig) (*SearchResult, error) {
 		switch v := fallbackConfig.(type) {
 		case string:
 			configUrl := v
-			dialer, err := configModule.NewStreamDialer(ctx, configUrl)
+			dialer, err := configModule.NewStreamDialer(raceCtx, configUrl)
 			if err != nil {
 				return nil, fmt.Errorf("getStreamDialer failed: %w", err)
 			}
 
-			err = f.testDialer(ctx, dialer, testDomains, configUrl)
+			err = f.testDialer(raceCtx, dialer, testDomains, configUrl)
 			if err != nil {
 				return nil, err
 			}
@@ -374,15 +395,20 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 				if err != nil {
 					f.logCtx(ctx, "Error marshaling to JSON: %v, %v", psiphonCfg, err)
 				}
+				psiphonSignature := f.getPsiphonConfigSignature(psiphonJSON)
 
-				dialer, err := newPsiphonDialer(ctx, psiphonJSON)
+				dialer, err := newPsiphonDialer(ctx, psiphonJSON, psiphonSignature)
 				if err != nil {
 					return nil, fmt.Errorf("getPsiphonDialer failed: %w", err)
 				}
 
-				// TODO(laplante): test the psiphon dialer
+				err = f.testDialer(raceCtx, dialer, testDomains, psiphonSignature)
+				if err != nil {
+					f.logCtx(ctx, "error testing dialer: %v, %v", psiphonSignature, err)
+					return nil, err
+				}
 
-				return &SearchResult{dialer, string(psiphonJSON)}, nil
+				return &SearchResult{dialer, psiphonSignature}, nil
 			} else {
 				return nil, fmt.Errorf("unknown fallback type: %v", v)
 			}
@@ -395,6 +421,7 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 		return nil, fmt.Errorf("could not find a working fallback: %w", err)
 	}
 	f.log("🏆 selected fallback '%v' in %0.2fs\n\n", fallback.Config, time.Since(raceStart).Seconds())
+
 	return fallback.Dialer, nil
 }
 

--- a/x/smart/stream_dialer_test.go
+++ b/x/smart/stream_dialer_test.go
@@ -64,7 +64,7 @@ fallback:
 		Fallback: []fallbackEntryConfig{
 			"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1",
 			fallbackEntryStructConfig{
-				Psiphon: map[string]any {
+				Psiphon: map[string]any{
 					"PropagationChannelId": "FFFFFFFFFFFFFFFF",
 					"SponsorId":            "FFFFFFFFFFFFFFFF",
 				},
@@ -91,7 +91,7 @@ fallback:
 	expectedConfig := configConfig{
 		Fallback: []fallbackEntryConfig{
 			fallbackEntryStructConfig{
-				Psiphon: map[string]any {
+				Psiphon: map[string]any{
 					"PropagationChannelId": "FFFFFFFFFFFFFFFF",
 					"SponsorId":            "FFFFFFFFFFFFFFFF",
 				},
@@ -110,7 +110,7 @@ func Test_getPsiphonConfigSignature_ValidFields(t *testing.T) {
 		"ClientPlatform": "outline",
 		"ClientVersion": "1"
 	}`)
-	expected := "{PropagationChannelId: FFFFFFFFFFFFFFFF, SponsorId: FFFFFFFFFFFFFFFF}"
+	expected := "Psiphon: {PropagationChannelId: FFFFFFFFFFFFFFFF, SponsorId: FFFFFFFFFFFFFFFF}"
 	actual := finder.getPsiphonConfigSignature(config)
 	require.Equal(t, expected, actual)
 }

--- a/x/smart/stream_dialer_test.go
+++ b/x/smart/stream_dialer_test.go
@@ -110,7 +110,7 @@ func Test_getPsiphonConfigSignature_ValidFields(t *testing.T) {
 		"ClientPlatform": "outline",
 		"ClientVersion": "1"
 	}`)
-	expected := "Psiphon: {PropagationChannelId: FFFFFFFFFFFFFFFF, SponsorId: FFFFFFFFFFFFFFFF}"
+	expected := "Psiphon: {PropagationChannelId: FFFFFFFFFFFFFFFF, SponsorId: FFFFFFFFFFFFFFFF, [...]}"
 	actual := finder.getPsiphonConfigSignature(config)
 	require.Equal(t, expected, actual)
 }

--- a/x/smart/stream_dialer_test.go
+++ b/x/smart/stream_dialer_test.go
@@ -75,3 +75,61 @@ fallback:
 
 	require.Equal(t, expectedConfig, parsedConfig)
 }
+
+func TestParseConfig_YamlPsiphonConfig(t *testing.T) {
+	config := `
+fallback:
+  - psiphon: 
+      PropagationChannelId: FFFFFFFFFFFFFFFF
+      SponsorId: FFFFFFFFFFFFFFFF
+`
+	configBytes := []byte(config)
+	finder := &StrategyFinder{}
+	parsedConfig, err := finder.parseConfig(configBytes)
+	require.NoError(t, err)
+
+	expectedConfig := configConfig{
+		Fallback: []fallbackEntryConfig{
+			fallbackEntryStructConfig{
+				Psiphon: map[string]any {
+					"PropagationChannelId": "FFFFFFFFFFFFFFFF",
+					"SponsorId":            "FFFFFFFFFFFFFFFF",
+				},
+			},
+		},
+	}
+
+	require.Equal(t, expectedConfig, parsedConfig)
+}
+
+func Test_getPsiphonConfigSignature_ValidFields(t *testing.T) {
+	finder := &StrategyFinder{}
+	config := []byte(`{
+		"PropagationChannelId": "FFFFFFFFFFFFFFFF",
+		"SponsorId": "FFFFFFFFFFFFFFFF",
+		"ClientPlatform": "outline",
+		"ClientVersion": "1"
+	}`)
+	expected := "{PropagationChannelId: FFFFFFFFFFFFFFFF, SponsorId: FFFFFFFFFFFFFFFF}"
+	actual := finder.getPsiphonConfigSignature(config)
+	require.Equal(t, expected, actual)
+}
+
+func Test_getPsiphonConfigSignature_InvalidFields(t *testing.T) {
+	// If we don't understand the psiphon config we received for any reason
+	// then just output it as an opaque string
+
+	finder := &StrategyFinder{}
+	config := []byte(`{"ClientPlatform": "outline", "ClientVersion": "1"}`)
+	expected := `{"ClientPlatform": "outline", "ClientVersion": "1"}`
+	actual := finder.getPsiphonConfigSignature(config)
+	require.Equal(t, expected, actual)
+}
+
+func Test_getPsiphonConfigSignature_InvalidJson(t *testing.T) {
+	finder := &StrategyFinder{}
+	config := []byte(`invalid json`)
+	expected := `invalid json`
+	actual := finder.getPsiphonConfigSignature(config)
+	require.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Actually initialize psiphon connection when given a config.

## Updated docs:

- [smart](https://github.com/Jigsaw-Code/outline-sdk/blob/psiphon-fallback4/x/smart/README.md)
- [mobileproxy](https://github.com/Jigsaw-Code/outline-sdk/blob/psiphon-fallback4/x/mobileproxy/README.md)

## Tested

### 1. running smart proxy with a broken psiphon config

fails to connect as expected

```
go run -C ./examples/smart-proxy/ -tags psiphon . -v -localAddr=localhost:1080 --transport="" --domain ipinfo.com  --config=/Users/laplante/Projects/outline-sdk/x/examples/smart-proxy/config_broken.yaml
[...]
🏃 running test: 'ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1' (domain: ipinfo.com.)
Using data store in /Users/laplante/Library/Caches/psiphon
❌ Failed to start dialer: Psiphon: {PropagationChannelId: ID1, SponsorId: ID2, [...]} newPsiphonDialer failed: failed to start psiphon dialer: clientlib.StartTunnel#271: config.Commit failed: psiphon.(*Config).Commit#1412: missing RemoteServerListSignaturePublicKey
🏃 running test: 'socks5://192.168.1.10:1080' (domain: ipinfo.com.)
2025/04/16 14:21:23 Failed to find dialer: could not find a working fallback: all tests failed
exit status 1
```

### 2. running smart-proxy without the psiphon build tag

builds, but logs an error about the build tags when run

```
go run -C ./examples/smart-proxy/ . -v -localAddr=localhost:1080 --transport="" --domain ipinfo.com  --config=/Users/laplante/Projects/outline-sdk/x/examples/smart-proxy/config_broken.yaml
[...]
🏃 running test: 'ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1' (domain: ipinfo.com.)
❌ Failed to start dialer: Psiphon: {PropagationChannelId: ID1, SponsorId: ID2, [...]} newPsiphonDialer failed: attempted to start psiphon tunnel but library was built without psiphon support. Please build using -tag psiphon: unsupported operation
🏃 running test: 'socks5://192.168.1.10:1080' (domain: ipinfo.com.)
2025/04/16 14:20:52 Failed to find dialer: could not find a working fallback: all tests failed
exit status 1
```

### 3. running smart-proxy with our working firehook config

saw that the tunnel starts, and persists across many connection attempts (including succeeding after failed connection attempts)

```
go run -C ./examples/smart-proxy/ -tags psiphon . -v -localAddr=localhost:1080 --transport="" --domain "ipinfo.com" --config=/Users/laplante/Projects/outline-sdk/x/examples/smart-proxy/config_psiphon_firehook.yaml
Finding strategy
Using data store in /Users/laplante/Library/Caches/psiphon
🏃 running test: 'Psiphon: {PropagationChannelId: <REDACTED>, [...]}' (domain: ipinfo.com.)
🏁 success: 'Psiphon: {PropagationChannelId: <REDACTED>, [...]}' (domain: ipinfo.com.), duration=190.90125ms, status=ok ✅
🏆 selected fallback 'Psiphon: {PropagationChannelId: <REDACTED>, [...]}' in 0.80s
```

### 4. running smart-proxy with our working firehook config but with a failing canary domain 

Fails (as expected) on a nonexistant domain

```
go run -C ./examples/smart-proxy/ -tags psiphon . -v -localAddr=localhost:1080 --transport="" --domain "dfgsdfhsdfshfgh.com" --config=/Users/laplante/Projects/outline-sdk/x/examples/smart-proxy/config_psiphon_firehook.yaml
Finding strategy
Using data store in /Users/laplante/Library/Caches/psiphon
🏃 running test: 'Psiphon: {PropagationChannelId: <REDACTED>, [...]}' (domain: dfgsdfhsdfshfgh.com.)
🏁 failed to dial: 'Psiphon: {PropagationChannelId: <REDACTED>, [...]}' (domain: dfgsdfhsdfshfgh.com.), duration=52.288958ms, dial_error=psiphon.(*Controller).Dial#1413: psiphon.(*Tunnel).DialTCPChannel#585: psiphon.(*Tunnel).dialChannel#692: psiphon.(*Tunnel).dialChannel.func2#678: ssh: rejected: administratively prohibited (administratively prohibited) ❌
2025/04/16 14:18:47 Failed to find dialer: could not find a working fallback: all tests failed
exit status 1
```

### 5. sending a config where the psiphon content isn't valid json

```
go run -C ./examples/smart-proxy/ -tags psiphon . -v -localAddr=localhost:1080 --transport="" --domain ipinfo.com  --config=/Users/laplante/Projects/outline-sdk/x/examples/smart-proxy/config_psiphon_garbled.yaml
Finding strategy
Using data store in /Users/laplante/Library/Caches/psiphon
❌ Failed to start dialer: "aaaaaaaa" newPsiphonDialer failed: failed to start psiphon dialer: clientlib.StartTunnel#227: failed to load config file: psiphon.LoadConfig#1149: json: cannot unmarshal string into Go value of type psiphon.Config
2025/04/16 14:44:09 Failed to find dialer: could not find a working fallback: all tests failed
exit status 1
```

### 6. successfully choosing a good outline config over a bad psiphon config

Expect that the selection race doesn't output any late logging about a failed psiphon config after picking a working outline config

```
go run -C ./examples/smart-proxy/ -tags psiphon . -v -localAddr=localhost:1082 --transport="" --domain "ipinfo.com" --config=/Users/laplante/Projects/outline-sdk/x/examples/smart-proxy/config_two_fallbacks_one_bad.yaml
Finding strategy
Using data store in /Users/laplante/Library/Caches/psiphon
🏃 running test: '<REDACTED OUTLINE CONFIG>' (domain: ipinfo.com.)
🏁 success: 'REDACTED OUTLINE CONFIG' (domain: ipinfo.com.), duration=258.623542ms, status=ok ✅
🏆 selected fallback 'REDACTED OUTLINE CONFIG' in 0.51s

Found strategy in 0.51s
Proxy listening on 127.0.0.1:1082
```

## Not tested

- using psiphon inside of mobileproxy