### PR TITLE
feat(x) vary getPsiphonDialer implementation depending on build tag

### DIFF
--- a/x/smart/psiphon_dialer.go
+++ b/x/smart/psiphon_dialer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Jigsaw-Code/outline-sdk/x/psiphon"
 )
 
-func getPsiphonDialer(ctx context.Context, psiphonJSON []byte) (transport.StreamDialer, error) {
+func newPsiphonDialer(ctx context.Context, psiphonJSON []byte) (transport.StreamDialer, error) {
 	// Test calling psiphon package to prove it works
 	dialer := psiphon.GetSingletonDialer()
 	fmt.Printf("Initializing psiphon dialer: %+v\n", dialer)

--- a/x/smart/psiphon_dialer.go
+++ b/x/smart/psiphon_dialer.go
@@ -1,0 +1,23 @@
+// +build psiphon
+// If the build tag `psiphon` is set, allow importing and calling psiphon
+
+package smart
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+	"github.com/Jigsaw-Code/outline-sdk/x/psiphon"
+)
+
+func getPsiphonDialer(ctx context.Context, psiphonJSON []byte) (transport.StreamDialer, error) {
+	// Test calling psiphon package to prove it works
+	dialer := psiphon.GetSingletonDialer()
+	fmt.Printf("Initializing psiphon dialer: %+v\n", dialer)
+
+	//TODO(laplante): set up and use psiphon dialer
+
+	return nil, fmt.Errorf("psiphon is not yet supported, skipping: %w", errors.ErrUnsupported) 
+}

--- a/x/smart/psiphon_dialer_unimplemented.go
+++ b/x/smart/psiphon_dialer_unimplemented.go
@@ -11,6 +11,6 @@ import (
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 )
 
-func getPsiphonDialer(ctx context.Context, psiphonJSON []byte) (transport.StreamDialer, error) {
+func newPsiphonDialer(ctx context.Context, psiphonJSON []byte) (transport.StreamDialer, error) {
 	return nil, fmt.Errorf("To use psiphon configuration in x/smart the package must be built with the build tag `psiphon`: %w", errors.ErrUnsupported) 
 }

--- a/x/smart/psiphon_dialer_unimplemented.go
+++ b/x/smart/psiphon_dialer_unimplemented.go
@@ -1,0 +1,16 @@
+//go:build !psiphon
+// If the build tag `psiphon` is not set, create a stub function to avoid pulling in GPL'd code
+
+package smart
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+)
+
+func getPsiphonDialer(ctx context.Context, psiphonJSON []byte) (transport.StreamDialer, error) {
+	return nil, fmt.Errorf("To use psiphon configuration in x/smart the package must be built with the build tag `psiphon`: %w", errors.ErrUnsupported) 
+}

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -375,9 +375,14 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 					f.logCtx(ctx, "Error marshaling to JSON: %v, %v", psiphonCfg, err)
 				}
 
-				// TODO(laplante): pass this forward into psiphon.go, which takes raw json
-				f.logCtx(ctx, "❌ Psiphon is not yet supported, skipping: %v\n", string(psiphonJSON))
-				return nil, fmt.Errorf("psiphon is not yet supported: %v", string(psiphonJSON))
+				dialer, err := getPsiphonDialer(ctx, psiphonJSON)
+				if err != nil {
+					return nil, fmt.Errorf("getPsiphonDialer failed: %w", err)
+				}
+
+				// TODO(laplante): test the psiphon dialer
+
+				return &SearchResult{dialer, string(psiphonJSON)}, nil
 			} else {
 				return nil, fmt.Errorf("unknown fallback type: %v", v)
 			}

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -375,7 +375,7 @@ func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string,
 					f.logCtx(ctx, "Error marshaling to JSON: %v, %v", psiphonCfg, err)
 				}
 
-				dialer, err := getPsiphonDialer(ctx, psiphonJSON)
+				dialer, err := newPsiphonDialer(ctx, psiphonJSON)
 				if err != nil {
 					return nil, fmt.Errorf("getPsiphonDialer failed: %w", err)
 				}


### PR DESCRIPTION
Make a stub `getPsiphonDialer` implementation in `smart` that differs depending on the `psiphon` build tag. This way we can avoid pulling any GPL'd psiphon code into `smart-proxy`/`mobileproxy` without the build tag.

This does not actually fully implement setting up the psiphon dialer, just tests that the psiphon library can be imported and called. That work will be in https://github.com/Jigsaw-Code/outline-sdk/pull/404. 

## Tested
 
running
```
go run -C ./examples/smart-proxy/ -tags psiphon . -v -localAddr=localhost:1080 --transport="" --domain "ipinfo.com" --config=config_psiphon.yaml
```
and without the tag

Once psiphon support is implemented we'll want to add some documentation to 
- https://github.com/Jigsaw-Code/outline-sdk/blob/main/x/mobileproxy/README.md
- https://github.com/Jigsaw-Code/outline-sdk/blob/main/x/smart/README.md

about building with psiphon support.
