### PR TITLE
bug(x) don't attempt to fallback when there are no fallbacks

### DIFF
--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -340,7 +340,7 @@ func (f *StrategyFinder) findTLS(ctx context.Context, testDomains []string, base
 // Return the fastest fallback dialer that is able to access all the testDomans
 func (f *StrategyFinder) findFallback(ctx context.Context, testDomains []string, fallbackConfigs []fallbackEntryConfig) (transport.StreamDialer, error) {
 	if len(fallbackConfigs) == 0 {
-		return nil, errors.New("no fallback was specified")
+		return nil, errors.New("attempted to find fallback but no fallback configuration was specified")
 	}
 
 	ctx, searchDone := context.WithCancel(ctx)
@@ -473,7 +473,7 @@ func (f *StrategyFinder) NewDialer(ctx context.Context, testDomains []string, co
 	}
 
 	dialer, err := f.newProxylessDialer(ctx, testDomains, parsedConfig)
-	if err != nil {
+	if err != nil && parsedConfig.Fallback != nil {
 		return f.findFallback(ctx, testDomains, parsedConfig.Fallback)
 	}
 	return dialer, err


### PR DESCRIPTION
Currently if all proxyless strategies fail and there are no fallbacks in the config we return a confusing error about the lack of fallbacks.

`failed to find dialer: no fallback was specified`

### Tested

when running against `config_broken.yaml` where everything is broken we expect to get an error about fallbacks.

```
go run -C ./examples/smart-proxy/ -tags psiphon . -v -localAddr=localhost:1080 --transport="" --domain "ipinfo.com"  --config=/Users/laplante/Projects/outline-sdk/x/examples/smart-proxy/config_broken.yaml
...
2025/04/08 11:21:25 Failed to find dialer: could not find a working fallback: all tests failed
```

Then did the same test after removing the fallback section from `config_broken.yaml` and saw a clearer error for failed proxyless

```
[...]
2025/04/08 11:24:42 Failed to find dialer: could not find working resolver: all tests failed
```

