### PR TITLE
feat: enable TLS cert verification extensions

### DIFF
--- a/transport/tls/stream_dialer.go
+++ b/transport/tls/stream_dialer.go
@@ -130,8 +130,8 @@ func WrapConn(ctx context.Context, conn transport.StreamConn, serverName string,
 		option(normName, &cfg)
 	}
 	if cfg.CertVerifier == nil {
-		// If VerifyCertFunction is not provided, use the default verification logic,
-		// which validates the peer certificate against the SNI.
+		// If CertVerifier is not provided, use the default verification logic,
+		// which validates the peer certificate against the provided serverName.
 		cfg.CertVerifier = &StandardCertVerifier{CertificateName: serverName}
 	}
 	tlsConn := tls.Client(conn, cfg.toStdConfig())

--- a/transport/tls/stream_dialer_test.go
+++ b/transport/tls/stream_dialer_test.go
@@ -77,7 +77,7 @@ func TestIP(t *testing.T) {
 }
 
 func TestIPOverride(t *testing.T) {
-	sd, err := NewStreamDialer(&transport.TCPDialer{}, WithCertificateName("8.8.8.8"))
+	sd, err := NewStreamDialer(&transport.TCPDialer{}, WithCertVerifier(&StandardCertVerifier{CertificateName: "8.8.8.8"}))
 	require.NoError(t, err)
 	conn, err := sd.DialStream(context.Background(), "dns.google:443")
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestNoSNI(t *testing.T) {
 }
 
 func TestAllCustom(t *testing.T) {
-	sd, err := NewStreamDialer(&transport.TCPDialer{}, WithSNI("decoy.android.com"), WithCertificateName("www.youtube.com"))
+	sd, err := NewStreamDialer(&transport.TCPDialer{}, WithSNI("decoy.android.com"), WithCertVerifier(&StandardCertVerifier{CertificateName: "www.youtube.com"}))
 	require.NoError(t, err)
 	conn, err := sd.DialStream(context.Background(), "www.google.com:443")
 	require.NoError(t, err)

--- a/transport/tls/stream_dialer_test.go
+++ b/transport/tls/stream_dialer_test.go
@@ -249,7 +249,7 @@ func TestGeneratedCert_Valid(t *testing.T) {
 	verificationContext := &CertVerificationContext{PeerCertificates: []*x509.Certificate{leafCert}}
 
 	sysVerifier := &StandardCertVerifier{CertificateName: "test.local"}
-	require.ErrorContains(t, sysVerifier.VerifyCertificate(verificationContext), "not trusted")
+	require.Error(t, sysVerifier.VerifyCertificate(verificationContext))
 
 	customVerifier := &StandardCertVerifier{CertificateName: "test.local", Roots: rootPool}
 	require.NoError(t, customVerifier.VerifyCertificate(verificationContext))

--- a/transport/tls/stream_dialer_test.go
+++ b/transport/tls/stream_dialer_test.go
@@ -16,8 +16,15 @@ package tls
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/stretchr/testify/require"
@@ -175,4 +182,81 @@ func (d *connCounterDialer) DialStream(ctx context.Context, raddr string) (trans
 func (c countedStreamConn) Close() error {
 	c.counter.activeConns--
 	return c.StreamConn.Close()
+}
+
+// Helper function to create a self-signed certificate (Root CA)
+func createRootCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"Test Root CA"}},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privKey.PublicKey, privKey)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	return cert, privKey
+}
+
+// Helper function to create a leaf certificate signed by a parent
+func createLeafCert(t *testing.T, dnsNames []string, ipAddresses []net.IP, parentCert *x509.Certificate, parentKey *ecdsa.PrivateKey, notBefore, notAfter time.Time) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: dnsNames[0]}, // Use first DNS name as CN
+		DNSNames:              dnsNames,
+		IPAddresses:           ipAddresses,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, // Server cert
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, parentCert, &privKey.PublicKey, parentKey)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	return cert, privKey
+}
+
+func TestGeneratedCert_Valid(t *testing.T) {
+	// 1. Generate Certs
+	rootCA, rootKey := createRootCA(t)
+	leafCert, _ := createLeafCert(t, []string{"test.local"}, nil, rootCA, rootKey, time.Now().Add(-1*time.Hour), time.Now().Add(1*time.Hour))
+
+	// 2. Setup Root Pool for Client
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(rootCA)
+
+	verificationContext := &CertVerificationContext{PeerCertificates: []*x509.Certificate{leafCert}}
+
+	sysVerifier := &StandardCertVerifier{CertificateName: "test.local"}
+	require.ErrorContains(t, sysVerifier.VerifyCertificate(verificationContext), "not trusted")
+
+	customVerifier := &StandardCertVerifier{CertificateName: "test.local", Roots: rootPool}
+	require.NoError(t, customVerifier.VerifyCertificate(verificationContext))
+
+	wrongDomainVerifier := &StandardCertVerifier{CertificateName: "other.local", Roots: rootPool}
+	var hostErr x509.HostnameError
+	require.ErrorAs(t, wrongDomainVerifier.VerifyCertificate(verificationContext), &hostErr)
+	require.Equal(t, "other.local", hostErr.Host)
+	require.Equal(t, leafCert, hostErr.Certificate)
 }


### PR DESCRIPTION
This change makes it possible to easily customize the TLS certificate validation.

Instead of adding a bunch of parameters to the TLS config, we add a single verifier that can be built in different ways. This is a more scalable design.

This allows for setting the root CAs, superseding https://github.com/Jigsaw-Code/outline-sdk/pull/337 and fixing https://github.com/Jigsaw-Code/outline-sdk/issues/315.

/cc @garmr-ulfr