### PR TITLE
bug(x) fix psiphon wrapper context

### DIFF
--- a/x/psiphon/psiphon.go
+++ b/x/psiphon/psiphon.go
@@ -133,7 +133,7 @@ func (d *Dialer) Start(startCtx context.Context, config *DialerConfig) error {
 		}
 
 		// startCtx is intended for the lifetime of the startup.
-		// dialerCtx is intented for the lifetime of the tunnel.
+		// dialerCtx is intended for the lifetime of the tunnel.
 		dialerCtx, dialerCancel := context.WithCancel(context.Background())
 		defer dialerCancel()
 

--- a/x/psiphon/psiphon_test.go
+++ b/x/psiphon/psiphon_test.go
@@ -139,7 +139,7 @@ func TestDialer_Start_Timeout(t *testing.T) {
 		errCh <- GetSingletonDialer().Start(ctx, cfg)
 	}()
 	err := <-errCh
-	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 type errorTunnel struct {


### PR DESCRIPTION
Use two contexts for psiphon so we don't cancel the tunnel if the input context is cancelled

Testing:
added the ability to run integration tests with a secret config in https://github.com/Jigsaw-Code/outline-sdk/pull/430