### PR TITLE
chore: commenting out flaky test

### DIFF
--- a/transport/happyeyeballs_test.go
+++ b/transport/happyeyeballs_test.go
@@ -225,6 +225,7 @@ func TestHappyEyeballsStreamDialer_DialStream(t *testing.T) {
 		require.Equal(t, []string{"[2001:4860:4860::8888]:53", "8.8.8.8:53"}, dialedAddrs)
 	})
 
+	/* Commenting out flaky test until we have time to fix the race condition
 	t.Run("IP order", func(t *testing.T) {
 		dialFailErr := errors.New("failed to dial")
 		baseDialer := collectStreamDialer{Dialer: newErrorStreamDialer(dialFailErr)}
@@ -251,6 +252,7 @@ func TestHappyEyeballsStreamDialer_DialStream(t *testing.T) {
 		require.ErrorIs(t, err, dialFailErr)
 		require.Equal(t, []string{"[::1]:53", "1.1.1.1:53", "[::2]:53", "2.2.2.2:53", "[::3]:53", "3.3.3.3:53"}, baseDialer.Addrs)
 	})
+	*/
 
 	t.Run("Cancelled lookups", func(t *testing.T) {
 		var hold sync.WaitGroup


### PR DESCRIPTION
Commenting out `TestHappyEyeballsStreamDialer_DialStream/IP order` which flakes out around 10-25% of the time, until we have time to fix the underlying race condition.

Obviously it would be best to fix the bug, but since we don't have time at the moment, best to remove the flake