### PR TITLE
test(x): remove flaky check in test

### DIFF
--- a/x/smart/stream_dialer_integration_test.go
+++ b/x/smart/stream_dialer_integration_test.go
@@ -98,7 +98,6 @@ fallback:
 	// Different systems have different network error messages,
 	// so we only check the broad strokes.
 	expectedLogs := []string{
-		"rcode is not success: RCodeRefused ❌",
 		"request for A query failed: dial DNS resolver failed:",
 		`request for A query failed: receive DNS message failed: failed to get HTTP response: Post "https://mitm-software.badssl.com:443/dns-query": tls:`,
 		"🏃 running test: 'ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTprSzdEdHQ0MkJLOE9hRjBKYjdpWGFK@1.2.3.4:9999/?outline=1'",


### PR DESCRIPTION
This check in my integration test occasionally flakes out when the remote DNS server doesn't respond as expected. (ex: https://github.com/Jigsaw-Code/outline-sdk/actions/runs/14994785745/job/42126315765?pr=450)

I'm removing the line to not have flakes in our tests.