### PR TITLE
Implement minor sanity checks in the web wrapper app build script

### DIFF
--- a/x/examples/website-wrapper-app/wrapper_app_project/.scripts/build.mjs
+++ b/x/examples/website-wrapper-app/wrapper_app_project/.scripts/build.mjs
@@ -136,7 +136,7 @@ export default async function main(
 
   console.log("Installing external dependencies for the project...");
   await promisify(exec)(`
-    cd ${WRAPPER_APP_OUTPUT_DIR}
+    cd ${WRAPPER_APP_OUTPUT_DIR.replaceAll(" ", "\\ ")}
     npm install
     npx cap sync ${platform}
   `);
@@ -227,7 +227,7 @@ function resolveTemplateArguments(
   return result;
 }
 
-if (import.meta.url.endsWith(process.argv[1])) {
+if (decodeURI(import.meta.url).endsWith(process.argv[1])) {
   const args = minimist(process.argv.slice(2));
 
   if (!args.platform) {


### PR DESCRIPTION
Add some small sanity checks in the build script of the web wrapper example. This may not be a complete implementation. The currently suggestions allow for spaces in paths when invoking the build script on Mac cli. I would assume this to work in other Linux-based environments as well but I have no idea how this behaves on Windows.