### PR TITLE
feat(x): log on dialer test timeout

### DIFF
--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -250,21 +250,31 @@ func (f *StrategyFinder) testDialer(ctx context.Context, dialer transport.Stream
 		testAddr := net.JoinHostPort(testDomain, "443")
 		f.logCtx(ctx, "🏃 running test: '%v' (domain: %v)\n", transportCfg, testDomain)
 
-		ctx, cancel := context.WithTimeout(ctx, f.TestTimeout)
+		testCtx, cancel := context.WithTimeout(ctx, f.TestTimeout)
 		defer cancel()
-		testConn, err := dialer.DialStream(ctx, testAddr)
+
+		timeoutChan := make(chan struct{})
+		go func() {
+			<-testCtx.Done()
+			if errors.Is(testCtx.Err(), context.DeadlineExceeded) {
+				f.logCtx(testCtx, "⏱️ dialer failure, test timed out: '%v' (domain: %v), duration=%v ❌\n", transportCfg, testDomain, time.Since(startTime))
+				close(timeoutChan)
+			}
+		}()
+
+		testConn, err := dialer.DialStream(testCtx, testAddr)
 		if err != nil {
-			f.logCtx(ctx, "🏁 failed to dial: '%v' (domain: %v), duration=%v, dial_error=%v ❌\n", transportCfg, testDomain, time.Since(startTime), err)
+			f.logCtx(testCtx, "🏁 failed to dial: '%v' (domain: %v), duration=%v, dial_error=%v ❌\n", transportCfg, testDomain, time.Since(startTime), err)
 			return err
 		}
 		tlsConn := tls.Client(testConn, &tls.Config{ServerName: testDomain})
-		err = tlsConn.HandshakeContext(ctx)
+		err = tlsConn.HandshakeContext(testCtx)
 		tlsConn.Close()
 		if err != nil {
-			f.logCtx(ctx, "🏁 failed TLS handshake: '%v' (domain: %v), duration=%v, handshake=%v ❌\n", transportCfg, testDomain, time.Since(startTime), err)
+			f.logCtx(testCtx, "🏁 failed TLS handshake: '%v' (domain: %v), duration=%v, handshake=%v ❌\n", transportCfg, testDomain, time.Since(startTime), err)
 			return err
 		}
-		f.logCtx(ctx, "🏁 success: '%v' (domain: %v), duration=%v, status=ok ✅\n", transportCfg, testDomain, time.Since(startTime))
+		f.logCtx(testCtx, "🏁 success: '%v' (domain: %v), duration=%v, status=ok ✅\n", transportCfg, testDomain, time.Since(startTime))
 	}
 	return nil
 }

--- a/x/smart/stream_dialer.go
+++ b/x/smart/stream_dialer.go
@@ -256,7 +256,7 @@ func (f *StrategyFinder) testDialer(ctx context.Context, dialer transport.Stream
 		timeoutChan := make(chan struct{})
 		go func() {
 			<-testCtx.Done()
-			if errors.Is(testCtx.Err(), context.DeadlineExceeded) {
+			if errors.Is(context.Cause(testCtx), context.DeadlineExceeded) {
 				f.logCtx(testCtx, "⏱️ dialer failure, test timed out: '%v' (domain: %v), duration=%v ❌\n", transportCfg, testDomain, time.Since(startTime))
 				close(timeoutChan)
 			}


### PR DESCRIPTION
Log a statement when the dialer test times out instead of failing silently.

Tested:

You can see some examples of this logging (with some other changes) [here](https://docs.google.com/document/d/1az_60EYFwMpoV8Nrcl-6WcU9AIzs9TutiWojXOh45Kg/edit?tab=t.0#heading=h.qp2wm9g0ohb2)

[logging output test examples](https://docs.google.com/document/d/1g8aQ0kxEPsyqYRcHVmoZmz1yHOcIu847I0MWHkwGkCU/edit?usp=sharing&resourcekey=0-tJfqiaVK4d9aJwbXLeFpvw)