### PR TITLE
website-wrapper-app: Add engines.node to package.json

### DIFF
--- a/x/examples/website-wrapper-app/package.json
+++ b/x/examples/website-wrapper-app/package.json
@@ -13,6 +13,9 @@
     "handlebars": "^4.7.8",
     "vite": "^6.2.0"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "license": "Apache-2.0",
   "scripts": {
     "build:mobileproxy": "bash ./.scripts/build_mobileproxy.sh",


### PR DESCRIPTION
This adds the engines.node property to warn users and contributors if they’re using an unsupported Node version. Personally I use [`fnm`](https://github.com/Schniz/fnm) which auto-loads the specified Node version on entering the directory.

I figure LTS is a good target, and it’s [what you’re doing in `outline-client`](https://github.com/Jigsaw-Code/outline-apps/blob/master/package.json#L18-L20). But I see the [`connectivity-app` app example uses `18.x`](https://github.com/Jigsaw-Code/outline-sdk/blob/71af1bbadc2024d45c7cc6af0119e79376e5d852/x/examples/connectivity-app/package.json#L12-L14).