### PR TITLE
website-wrapper-app: Fix "ReferenceError: data is not defined" error in getYAMLFileConfig

### DIFF
--- a/x/examples/website-wrapper-app/wrapper_app_project/.scripts/config.mjs
+++ b/x/examples/website-wrapper-app/wrapper_app_project/.scripts/config.mjs
@@ -25,13 +25,14 @@ export const DEFAULT_CONFIG = {
 export async function getYAMLFileConfig(filepath) {
   try {
     const data = await fs.readFile(filepath, 'utf8')
+    
+    if (data) {
+      return YAML.parse(data)
+    }
   } catch (e) {
     if ('ENOENT' == e.code) {
       return {}
     }
-  }
-  if (data) {
-    return YAML.parse(data)
   }
 }
 


### PR DESCRIPTION
With the previous logic data would never be defined outside of the `try...catch` block since `const` variables are block scoped.

(Let me know if I’m misunderstanding something here!)