### PR TITLE
website-wrapper-app: Add TypeScript checking via JSDoc type annotations

### DIFF
--- a/x/examples/website-wrapper-app/.gitignore
+++ b/x/examples/website-wrapper-app/.gitignore
@@ -1,2 +1,3 @@
+!.vscode/
 output/
 node_modules/

--- a/x/examples/website-wrapper-app/.vscode/settings.json
+++ b/x/examples/website-wrapper-app/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "js/ts.implicitProjectConfig.checkJs": true,
+  "typescript.preferences.importModuleSpecifier": "relative",
+  "typescript.preferences.importModuleSpecifierEnding": "auto",
+  "typescript.preferences.quoteStyle": "single",
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+}

--- a/x/examples/website-wrapper-app/package-lock.json
+++ b/x/examples/website-wrapper-app/package-lock.json
@@ -15,8 +15,11 @@
         "yaml": "^2.7.1"
       },
       "devDependencies": {
+        "@types/archiver": "^6.0.3",
+        "@types/minimist": "^1.2.5",
         "glob": "^11.0.1",
         "handlebars": "^4.7.8",
+        "typescript": "^5.8.3",
         "vite": "^6.2.0"
       }
     },
@@ -920,21 +923,46 @@
         "win32"
       ]
     },
+    "node_modules/@types/archiver": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.3.tgz",
+      "integrity": "sha512-a6wUll6k3zX6qs5KlxIggs1P1JcYJaTCx2gnlr+f0S1yd2DoaEwoIK10HmBaLnZwWneBz+JBm0dwcZu0zECBcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/abort-controller": {
@@ -2040,6 +2068,20 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -2057,9 +2099,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/x/examples/website-wrapper-app/package.json
+++ b/x/examples/website-wrapper-app/package.json
@@ -9,8 +9,11 @@
     "yaml": "^2.7.1"
   },
   "devDependencies": {
+    "@types/archiver": "^6.0.3",
+    "@types/minimist": "^1.2.5",
     "glob": "^11.0.1",
     "handlebars": "^4.7.8",
+    "typescript": "^5.8.3",
     "vite": "^6.2.0"
   },
   "license": "Apache-2.0",
@@ -20,7 +23,8 @@
     "clean": "npx rimraf node_modules/ output/",
     "doctor": "./doctor",
     "reset": "npm run clean && npm ci",
-    "start:navigator": "node ./basic_navigator_example/.scripts/start.mjs"
+    "start:navigator": "node ./basic_navigator_example/.scripts/start.mjs",
+    "typescript:check": "tsc --noEmit"
   },
   "private": true
 }

--- a/x/examples/website-wrapper-app/tsconfig.json
+++ b/x/examples/website-wrapper-app/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "module": "node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "**/*.cjs",
+    "**/*.mjs",
+    "**/*.js",
+    "**/.*/**/*.cjs",
+    "**/.*/**/*.mjs",
+    "**/.*/**/*.js",
+  ],
+  "exclude": [
+    "basic_navigator_example", // TODO: Remove this exclusion?
+    "node_modules",
+  ]
+}

--- a/x/examples/website-wrapper-app/wrapper_app_project/.scripts/config.mjs
+++ b/x/examples/website-wrapper-app/wrapper_app_project/.scripts/config.mjs
@@ -22,19 +22,37 @@ export const DEFAULT_CONFIG = {
   })
 }
 
+/**
+ * @param {string} filepath
+ * @returns {Promise<{}>}
+ */
 export async function getYAMLFileConfig(filepath) {
   try {
     const data = await fs.readFile(filepath, 'utf8')
-  } catch (e) {
-    if ('ENOENT' == e.code) {
-      return {}
+    
+    if (data) {
+      const parsedData = YAML.parse(data);
+
+      if (parsedData && typeof parsedData === 'object' && !Array.isArray(parsedData)) {
+        // This type assertion may not be 100% guaranteed but for the purposes
+        // of this use case should be correct
+        return /** @type {{}} */ (parsedData);
+      } else {
+        console.warn(`${filepath} contained invalid config data:`, parsedData)
+      }
+    } else {
+      console.warn(`${filepath} contained no data`)
     }
+  } catch (e) {
+    console.warn(`Error loading ${filepath}:`, e)
   }
-  if (data) {
-    return YAML.parse(data)
-  }
+
+  return {};
 }
 
+/**
+ * @param {NodeJS.Process["argv"]} args
+ */
 export function getCliConfig(args) {
   const dict = minimist(args)
   return {

--- a/x/examples/website-wrapper-app/wrapper_app_project/.scripts/types.mjs
+++ b/x/examples/website-wrapper-app/wrapper_app_project/.scripts/types.mjs
@@ -1,0 +1,13 @@
+
+/**
+ * @typedef {{
+ *   additionalDomains: Array<string>;
+ *   appId: string;
+ *   appName: string;
+ *   domainList: string;
+ *   entryDomain: string;
+ *   output: string;
+ *   platform: string;
+ *   smartDialerConfig: string;
+ * }} Config
+ */


### PR DESCRIPTION
(Let me know if this is something you’re interested in at all -- I like having type safety for the project but I know TypeScript imposes some additional burden on contributors and maintainers.)

I started this because while working on #472 I noticed `getYAMLFileConfig` had some additional edge cases where undefined could get returned, but figured I could fully implement type safety in `wrapper_app_project` while I was at it.

Some notes:

* Adds a basic `tsconfig.json` with `"strict"` enabled, but type checking in `basic_navigator_example` disabled for now. You can run type checking with a new `"typescript:check"` script.

* Adds `.vscode/settings.json` to configure VS Code to do type checking and match the existing code style

* I’m not super familiar with the config format so I may be making some incorrect assumptions here.