### PR TITLE
website-wrapper-app: Restore open:* scripts (removed in #458)

### DIFF
--- a/x/examples/website-wrapper-app/package.json
+++ b/x/examples/website-wrapper-app/package.json
@@ -19,6 +19,8 @@
     "build": "node ./wrapper_app_project/.scripts/build.mjs",
     "clean": "npx rimraf node_modules/ output/",
     "doctor": "./doctor",
+    "open:android": "cd $(find output -mindepth 1 -maxdepth 1 -type d ! -name 'mobileproxy' | head -n 1) && npm run open:android",
+    "open:ios": "cd $(find output -mindepth 1 -maxdepth 1 -type d ! -name 'mobileproxy' | head -n 1) && npm run open:ios",
     "reset": "npm run clean && npm ci",
     "start:navigator": "node ./basic_navigator_example/.scripts/start.mjs"
   },


### PR DESCRIPTION
These were removed in #458:

https://github.com/Jigsaw-Code/outline-sdk/pull/458/files#diff-c2486eb7d0eaea9be3699c240db3784f1f1548d8c40b560f1ee5fa1f2fbe26c0L21-L22

I assume this was because the directory name of the project became dynamic.

This change replaces the previous `cd output/wrapper_app_project` with `cd $(find output -mindepth 1 -maxdepth 1 -type d ! -name 'mobileproxy' | head -n 1)`, which is essentially "open the first subdirectory of output not named "mobileproxy".

I don’t think there’s a good way to avoid the repetition but please let me know if you have any ideas.