### PR TITLE
docs(x): add psiphon tag in mobileproxy builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,12 +41,12 @@ jobs:
       - name: Build Mobileproxy (Android)
         if: matrix.os == 'ubuntu-latest'
         working-directory: ${{ github.workspace }}/x
-        run: PATH="${{ env.OUTPUT_DIR }}:$PATH" gomobile bind -ldflags='-s -w' -v -target=android -androidapi=21 -o "${{ env.OUTPUT_DIR }}/mobileproxy.aar" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
+        run: PATH="${{ env.OUTPUT_DIR }}:$PATH" gomobile bind -ldflags='-s -w' -v -tags=psiphon -target=android -androidapi=21 -o "${{ env.OUTPUT_DIR }}/mobileproxy.aar" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
 
       - name: Build Mobileproxy (iOS)
         if: matrix.os == 'macos-latest'
         working-directory: ${{ github.workspace }}/x
-        run: PATH="${{ env.OUTPUT_DIR }}:$PATH" gomobile bind -ldflags='-s -w' -v -target=ios -iosversion=11.0 -o "${{ env.OUTPUT_DIR }}/mobileproxy.xcframework" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
+        run: PATH="${{ env.OUTPUT_DIR }}:$PATH" gomobile bind -ldflags='-s -w' -v -tags=psiphon -target=ios -iosversion=11.0 -o "${{ env.OUTPUT_DIR }}/mobileproxy.xcframework" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
 
       - name: Check SDK licenses
         # We allow only "notice" type of licenses.

--- a/x/Taskfile.yml
+++ b/x/Taskfile.yml
@@ -31,7 +31,7 @@ tasks:
     desc: Builds Mobileproxy.xcframework for iOS.
     deps: [setup:mobileproxy]
     cmds:
-      - PATH={{.ROOT_DIR}}/{{.MOBILEPROXY_BUILD_TOOLS_DIR}}:$PATH gomobile bind -ldflags='-s -w' -tags=psiphon -target=ios -iosversion={{.IOS_MINIMUM_VERSION}} -o {{.ROOT_DIR}}/{{.IOS_FRAMEWORK_PATH}} {{.MOBILEPROXY_MODULE}}
+      - PATH={{.ROOT_DIR}}/{{.MOBILEPROXY_BUILD_TOOLS_DIR}}:$PATH gomobile bind -ldflags='-s -w' -target=ios -iosversion={{.IOS_MINIMUM_VERSION}} -o {{.ROOT_DIR}}/{{.IOS_FRAMEWORK_PATH}} {{.MOBILEPROXY_MODULE}}
       - (cd {{.ROOT_DIR}}/{{.MOBILEPROXY_ARTIFACT_DIR}} && zip -qr {{.IOS_ZIP_NAME}} {{.IOS_FRAMEWORK_NAME}})
     sources:
       - mobileproxy/**/*.go
@@ -45,7 +45,7 @@ tasks:
     desc: Builds mobileproxy.aar for Android.
     deps: [setup:mobileproxy]
     cmds:
-      - PATH={{.ROOT_DIR}}/{{.MOBILEPROXY_BUILD_TOOLS_DIR}}:$PATH gomobile bind -ldflags='-s -w' -tags=psiphon -target=android -androidapi={{.ANDROID_MIN_SDK_VERSION}} -o {{.ROOT_DIR}}/{{.ANDROID_AAR_PATH}} {{.MOBILEPROXY_MODULE}}
+      - PATH={{.ROOT_DIR}}/{{.MOBILEPROXY_BUILD_TOOLS_DIR}}:$PATH gomobile bind -ldflags='-s -w' -target=android -androidapi={{.ANDROID_MIN_SDK_VERSION}} -o {{.ROOT_DIR}}/{{.ANDROID_AAR_PATH}} {{.MOBILEPROXY_MODULE}}
     sources:
       - mobileproxy/**/*.go
       - go.mod

--- a/x/Taskfile.yml
+++ b/x/Taskfile.yml
@@ -31,7 +31,7 @@ tasks:
     desc: Builds Mobileproxy.xcframework for iOS.
     deps: [setup:mobileproxy]
     cmds:
-      - PATH={{.ROOT_DIR}}/{{.MOBILEPROXY_BUILD_TOOLS_DIR}}:$PATH gomobile bind -ldflags='-s -w' -target=ios -iosversion={{.IOS_MINIMUM_VERSION}} -o {{.ROOT_DIR}}/{{.IOS_FRAMEWORK_PATH}} {{.MOBILEPROXY_MODULE}}
+      - PATH={{.ROOT_DIR}}/{{.MOBILEPROXY_BUILD_TOOLS_DIR}}:$PATH gomobile bind -ldflags='-s -w' -tags=psiphon -target=ios -iosversion={{.IOS_MINIMUM_VERSION}} -o {{.ROOT_DIR}}/{{.IOS_FRAMEWORK_PATH}} {{.MOBILEPROXY_MODULE}}
       - (cd {{.ROOT_DIR}}/{{.MOBILEPROXY_ARTIFACT_DIR}} && zip -qr {{.IOS_ZIP_NAME}} {{.IOS_FRAMEWORK_NAME}})
     sources:
       - mobileproxy/**/*.go
@@ -45,7 +45,7 @@ tasks:
     desc: Builds mobileproxy.aar for Android.
     deps: [setup:mobileproxy]
     cmds:
-      - PATH={{.ROOT_DIR}}/{{.MOBILEPROXY_BUILD_TOOLS_DIR}}:$PATH gomobile bind -ldflags='-s -w' -target=android -androidapi={{.ANDROID_MIN_SDK_VERSION}} -o {{.ROOT_DIR}}/{{.ANDROID_AAR_PATH}} {{.MOBILEPROXY_MODULE}}
+      - PATH={{.ROOT_DIR}}/{{.MOBILEPROXY_BUILD_TOOLS_DIR}}:$PATH gomobile bind -ldflags='-s -w' -tags=psiphon -target=android -androidapi={{.ANDROID_MIN_SDK_VERSION}} -o {{.ROOT_DIR}}/{{.ANDROID_AAR_PATH}} {{.MOBILEPROXY_MODULE}}
     sources:
       - mobileproxy/**/*.go
       - go.mod

--- a/x/mobileproxy/README.md
+++ b/x/mobileproxy/README.md
@@ -45,8 +45,8 @@ go build -tags psiphon -o "$(pwd)/out/" golang.org/x/mobile/cmd/gomobile golang.
 Then build the iOS and Android libraries with [`gomobile bind`](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile#hdr-Build_a_library_for_Android_and_iOS)
 
 ```bash
-PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=ios -iosversion=11.0 -o "$(pwd)/out/mobileproxy.xcframework" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
-PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=android -androidapi=21 -o "$(pwd)/out/mobileproxy.aar" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
+PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=ios -iosversion=11.0 -tags=psiphon -o "$(pwd)/out/mobileproxy.xcframework" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
+PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=android -androidapi=21 -tags-psiphon -o "$(pwd)/out/mobileproxy.aar" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
 ```
 
 Note: Gomobile expects gobind to be in the PATH, that's why we need to prebuild it, and set up the PATH accordingly.

--- a/x/mobileproxy/README.md
+++ b/x/mobileproxy/README.md
@@ -45,6 +45,13 @@ go build -tags psiphon -o "$(pwd)/out/" golang.org/x/mobile/cmd/gomobile golang.
 Then build the iOS and Android libraries with [`gomobile bind`](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile#hdr-Build_a_library_for_Android_and_iOS)
 
 ```bash
+PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=ios -iosversion=11.0 -o "$(pwd)/out/mobileproxy.xcframework" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
+PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=android -androidapi=21 -o "$(pwd)/out/mobileproxy.aar" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
+```
+
+To include psiphon support please also include the `-tags=psiphon` flag.
+
+```bash
 PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=ios -iosversion=11.0 -tags=psiphon -o "$(pwd)/out/mobileproxy.xcframework" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
 PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=android -androidapi=21 -tags-psiphon -o "$(pwd)/out/mobileproxy.aar" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
 ```

--- a/x/mobileproxy/README.md
+++ b/x/mobileproxy/README.md
@@ -53,7 +53,7 @@ To include psiphon support please also include the `-tags=psiphon` flag.
 
 ```bash
 PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=ios -iosversion=11.0 -tags=psiphon -o "$(pwd)/out/mobileproxy.xcframework" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
-PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=android -androidapi=21 -tags-psiphon -o "$(pwd)/out/mobileproxy.aar" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
+PATH="$(pwd)/out:$PATH" gomobile bind -ldflags='-s -w' -target=android -androidapi=21 -tags=psiphon -o "$(pwd)/out/mobileproxy.aar" github.com/Jigsaw-Code/outline-sdk/x/mobileproxy
 ```
 
 Note: Gomobile expects gobind to be in the PATH, that's why we need to prebuild it, and set up the PATH accordingly.


### PR DESCRIPTION
This adds `-tags=psiphon` to our CI, and mentions it in the mobileproxy build documentation

discussion: [go/outline-psiphon](http://goto.google.com/outline-psiphon)