### PR TITLE
fix(x/mobileproxy): prevent panic when StrategyCache is not set

### DIFF
--- a/x/mobileproxy/stream_dialer.go
+++ b/x/mobileproxy/stream_dialer.go
@@ -101,7 +101,11 @@ func (opt *SmartDialerOptions) NewStreamDialer() (*StreamDialer, error) {
 		TestTimeout:  opt.testTimeout,
 		StreamDialer: opt.baseSD,
 		PacketDialer: opt.basePD,
-		Cache:        opt.cache,
+	}
+	// When assigning a nil concrete value to an interface, the interface is not nil
+	// but contains a nil value. The `if` check is necessary to avoid a panic.
+	if opt.cache != nil {
+		finder.Cache = opt.cache
 	}
 
 	dialer, err := finder.NewDialer(context.Background(), opt.testDomains, opt.config)


### PR DESCRIPTION
When `SmartDialerOptions.SetStrategyCache` is not called, `opt.cache` is `nil`. This `nil` value of type `*strategyCacheAdapter` is then assigned to the `Cache` field of `smart.StrategyFinder`, which is an interface.

This results in a non-nil interface with a nil value, which causes a panic when its methods are called inside `finder.NewDialer`.

This change fixes the issue by ensuring that a `nil` interface is passed to `smart.StrategyFinder` when `opt.cache` is `nil`, preventing the panic.

> Note that `LogWriter` doesn't need the same `if` check because `logWriter` is already an interface, so a nil `logWriter` is a true `nil` interface, which is safe to assign directly.

Fixes #501