### PR TITLE
release(x): retract broken versions that potentially cause panic

### DIFF
--- a/x/go.mod
+++ b/x/go.mod
@@ -2,7 +2,7 @@ module github.com/Jigsaw-Code/outline-sdk/x
 
 go 1.23.0
 
-// due to https://github.com/Jigsaw-Code/outline-sdk/issues/501
+// Due to https://github.com/Jigsaw-Code/outline-sdk/issues/501
 retract [v0.0.4, v0.0.6]
 
 require (


### PR DESCRIPTION
This change retracts releases `x/v0.0.4` through `x/v0.0.6` as they have been identified to be broken and can potentially cause a panic.