### PR TITLE
feat(x): add support for SOAX proxies

### DIFF
--- a/x/go.mod
+++ b/x/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/quic-go/quic-go v0.48.1
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/stretchr/testify v1.9.0
+	github.com/things-go/go-socks5 v0.0.5
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	golang.org/x/mobile v0.0.0-20240520174638-fa72addaaa1b
 	golang.org/x/net v0.36.0

--- a/x/soax/AGENTS.md
+++ b/x/soax/AGENTS.md
@@ -1,0 +1,1 @@
+README.md

--- a/x/soax/README.md
+++ b/x/soax/README.md
@@ -18,7 +18,7 @@ uses basic authentication ("username:password"), where the password is the Packa
 Proxy string:
 
 ```txt
-package-<pacakge_id>[-country-<country_iso>[-isp-<isp_name>][-region-<region_name>[-city-<city_name>]]][-sessionid-<session_id>-[sessionlength-<session_length>]]:<package_key>@proxy.soax.com:5000
+package-<package_id>[-country-<country_iso>[-isp-<isp_name>][-region-<region_name>[-city-<city_name>]]][-sessionid-<session_id>-[sessionlength-<session_length>]]:<package_key>@proxy.soax.com:5000
 ```
 
 The `isp_name`,`region_name` and `city_name` must be ones returned by the REST API. They may contain spaces, which should be replaced with `+` (e.g. `new+york`).
@@ -32,13 +32,13 @@ Here is an example of using SOCKS5 to connect from Germany:
 ```console
 $ curl --proxy "socks5h://package-${SOAX_PACKAGE_ID}-country-de-isp-o2+deutschland:${SOAX_PACKAGE_KEY}@proxy.soax.com:5000" https://checker.soax.com/api/ipinfo
 
-{"status":true,"reason":"","data":{"carrier":"O2 Deutschland","city":"Leipzig","country_code":"DE","country_name":"Germany","ip":"<redacted>","isp":"O2 Deutschland","region":"Saxony"}}                                         
+{"status":true,"reason":"","data":{"carrier":"O2 Deutschland","city":"Leipzig","country_code":"DE","country_name":"Germany","ip":"<redacted>","isp":"O2 Deutschland","region":"Saxony"}}
 ```
 
 Here is the same request using HTTP CONNECT:
 
 ```console
-$ curl --proxy "https://package-${SOAX_PACKAGE_ID}-country-de-isp-o2+deutschland:${SOAX_PACKAGE_KEY}@proxy.soax.com:5000" https://checker.soax.com/api/ipinfo 
+$ curl --proxy "https://package-${SOAX_PACKAGE_ID}-country-de-isp-o2+deutschland:${SOAX_PACKAGE_KEY}@proxy.soax.com:5000" https://checker.soax.com/api/ipinfo
 
 {"status":true,"reason":"","data":{"carrier":"O2 Deutschland","city":"Wuppertal","country_code":"DE","country_name":"Germany","ip":"176.1.206.77","isp":"O2 Deutschland","region":"North Rhine-Westphalia"}}
 ```
@@ -47,9 +47,9 @@ HTTP CONNECT is preferable because it can be done over HTTPS, which hides your c
 
 ### Sessions
 
-It's very important to use sessions in order to endure your requests are using the same proxy. By default, you will get a different proxy for each request.
+It's very important to use sessions in order to ensure your requests are using the same proxy. By default, you will get a different proxy for each request.
 
-To use the same proxy, craete a session by passing a `sessionid` and `sessionlength`, in seconds. Chasing the session ID changes the proxy used. When session length expires, you may get a new proxy.
+To use the same proxy, create a session by passing a `sessionid` and `sessionlength`, in seconds. Changing the session ID changes the proxy used. When session length expires, you may get a new proxy.
 
 For advanced session parameters, see [Understanding session parameters](https://helpcenter.soax.com/en/articles/9939557-understanding-session-parameters).
 

--- a/x/soax/README.md
+++ b/x/soax/README.md
@@ -1,0 +1,128 @@
+# SOAX Client
+
+SOAX is a provider of Residential, Mobile, and Datacenter proxy services. This document describes how to use its API.
+
+## Key Concepts
+
+* **Account:** User account, tied to the email you use to log in. You need to have your identity verified in order to enable the account.
+* **API Key:** Unique key tied to your account, used in the API calls. You can find it under USER > Profile. Keep it secret.
+* **Package:** Proxy packages give you access to the proxy service. Packages can be of various types based on where the proxy lives, including Residential, Mobile, Datacenter. The service website has a [list of available locations](https://soax.com/proxies/locations).
+* **Package ID:** A unique 6-digit identifier shown on each package in the package list UI. Used in proxy requests.
+* **Package Key:** Unique key tied to a specific package you have purchased. It shows up as "Password" in the web UI, under "QUICK ACCESS". Used in the REST API and proxy requests. Keep it secret.
+
+## SOAX Reference
+
+### Proxy API
+
+SOAX supports both HTTP CONNECT proxies and SOCKS5 proxies. In both cases it
+uses basic authentication ("username:password"), where the password is the Package Key, and the username is a configuration string specifying the parameters of the connection.
+
+Proxy string:
+
+```txt
+package-<pacakge_id>[-country-<country_iso>[-isp-<isp_name>][-region-<region_name>[-city-<city_name>]]][-sessionid-<session_id>-[sessionlength-<session_length>]]:<package_key>@proxy.soax.com:5000
+```
+
+The `isp_name`,`region_name` and `city_name` must be ones returned by the REST API. They may contain spaces, which should be replaced with `+` (e.g. `new+york`).
+
+For more details, see [Sticky sessions](https://helpcenter.soax.com/en/articles/6723733-sticky-sessions).
+
+It's helpful to use <https://checker.soax.com/api/ipinfo> to verify the location information of the proxy.
+
+Here is an example of using SOCKS5 to connect from Germany:
+
+```console
+$ curl --proxy "socks5h://package-${SOAX_PACKAGE_ID}-country-de-isp-o2+deutschland:${SOAX_PACKAGE_KEY}@proxy.soax.com:5000" https://checker.soax.com/api/ipinfo
+
+{"status":true,"reason":"","data":{"carrier":"O2 Deutschland","city":"Leipzig","country_code":"DE","country_name":"Germany","ip":"<redacted>","isp":"O2 Deutschland","region":"Saxony"}}                                         
+```
+
+Here is the same request using HTTP CONNECT:
+
+```console
+$curl --proxy "https://package-${SOAX_PACKAGE_ID}-country-de-isp-o2+deutschland:${SOAX_PACKAGE_KEY}@proxy.soax.com:5000" https://checker.soax.com/api/ipinfo 
+
+{"status":true,"reason":"","data":{"carrier":"O2 Deutschland","city":"Wuppertal","country_code":"DE","country_name":"Germany","ip":"176.1.206.77","isp":"O2 Deutschland","region":"North Rhine-Westphalia"}}
+```
+
+HTTP CONNECT is preferable because it can be done over HTTPS, which hides your credentials. That is not the case for SOCKS5. However, SOAX only supports TCP using HTTP CONNECT. For UDP, you will have to use SOCKS5 (see [HTTP vs SOCKS5 vs HTTPS: Which proxy protocol should you use?](https://helpcenter.soax.com/en/articles/7241369-http-vs-socks5-vs-https-which-proxy-protocol-should-you-use))
+
+### Sessions
+
+It's very important to use sessions in order to endure your requests are using the same proxy. By default, you will get a different proxy for each request.
+
+To use the same proxy, craete a session by passing a `sessionid` and `sessionlength`, in seconds. Chasing the session ID changes the proxy used. When session length expires, you may get a new proxy.
+
+For advanced session parameters, see [Understanding session parameters](https://helpcenter.soax.com/en/articles/9939557-understanding-session-parameters).
+
+### REST API
+
+[API Reference](https://helpcenter.soax.com/en/collections/3470979-api).
+
+API calls require both an API key, tied to the account, and a Package key, tied to the purchased package.
+
+Note that the APIs for mobile and residential packages differ a bit.
+
+#### Get list of mobile carriers
+
+This is for Mobile packages only.
+
+[Reference](https://helpcenter.soax.com/en/articles/6228381-getting-a-list-of-mobile-carriers)
+
+Request format:
+
+```txt
+https://api.soax.com/api/get-country-operators?api_key=<api_key>&package_key=<package_key>&country_iso=<country_iso>[&region=<region_name>[&city=<city_name>]]
+```
+
+Here is an example of listing the mobile ISPs in Russia:
+
+```console
+$ curl "https://api.soax.com/api/get-country-operators?api_key=$SOAX_API_KEY&package_key=$SOAX_PACKAGE_KEY&country_iso=ru"
+
+["pjsc megafon","mts pjsc","tele2 russia","beeline","rostelecom","jsc ufanet","edinos","ekaterinburg-2000","tbank jsc","er-telecom","t-mob","mcs","dom.ru","sberbank-telecom","llc sp abaza telecom","s.u.e. dpr republic operator of networks","tattelecom","edinos ltd.","invest mobile","isp balzer-telecom","innovation solutions center ltd.","novokuznetsk telecom","mobile trend","ooo network of data-centers selectel","dagnet","jv a-mobile","llc alfa-mobile","zao aquafon-gsm","ooo vtc-mobile"]
+```
+
+#### Get list of residential ISPS
+
+This is for Residential packages only. The official documentation refers to them as "WiFi ISPS".
+
+[Reference](https://helpcenter.soax.com/en/articles/6228391-getting-a-list-of-wifi-isps)
+
+Request format:
+
+```txt
+https://api.soax.com/api/get-country-isp?api_key=<api_key>&package_key=<package_key>&country_iso=<country_iso>[&region=<region_name>[&city=<city_name>]]
+```
+
+#### Get list of regions
+
+[Reference](https://helpcenter.soax.com/en/articles/6227864-getting-a-list-of-regions)
+
+Request format:
+
+```txt
+https://api.soax.com/api/get-country-regions?api_key=<api_key>&package_key=<package_key>&country_iso=<country_iso>&conn_type=<conn_type>[&provider=<provider>]
+```
+
+The `conn_type` parameter specifies the connection type. It must be `wifi` for residential proxies and `mobile` for mobile proxies.
+
+Here is an example of listing regions in Iran:
+
+```console
+$ curl  "https://api.soax.com/api/get-country-regions?api_key=$SOAX_API_KEY&package_key=$SOAX_PACKAGE_KEY&country_iso=ir&conn_type=mobile"
+
+["tehran","razavi khorasan","fars","isfahan","khuzestan","east azerbaijan province","alborz province","mazandaran","west azerbaijan province","gilan province","qom province"]
+```
+
+#### Get list of cities
+
+[Reference](https://helpcenter.soax.com/en/articles/6228092-getting-a-list-of-cities)
+
+Request format:
+
+```txt
+https://api.soax.com/api/get-country-cities?api_key=<api_key>&package_key=<package_key>&country_iso=<country_iso>&conn_type=<conn_type>[&provider=<provider_name>[&region=<region_name>]]
+```
+
+The `conn_type` parameter specifies the connection type. It must be `wifi` for residential proxies and `mobile` for mobile proxies.

--- a/x/soax/README.md
+++ b/x/soax/README.md
@@ -10,9 +10,7 @@ SOAX is a provider of Residential, Mobile, and Datacenter proxy services. This d
 * **Package ID:** A unique 6-digit identifier shown on each package in the package list UI. Used in proxy requests.
 * **Package Key:** Unique key tied to a specific package you have purchased. It shows up as "Password" in the web UI, under "QUICK ACCESS". Used in the REST API and proxy requests. Keep it secret.
 
-## SOAX Reference
-
-### Proxy API
+## SOAX Proxy API
 
 SOAX supports both HTTP CONNECT proxies and SOCKS5 proxies. In both cases it
 uses basic authentication ("username:password"), where the password is the Package Key, and the username is a configuration string specifying the parameters of the connection.
@@ -55,7 +53,7 @@ To use the same proxy, craete a session by passing a `sessionid` and `sessionlen
 
 For advanced session parameters, see [Understanding session parameters](https://helpcenter.soax.com/en/articles/9939557-understanding-session-parameters).
 
-### REST API
+## SOAX REST API
 
 [API Reference](https://helpcenter.soax.com/en/collections/3470979-api).
 
@@ -63,7 +61,7 @@ API calls require both an API key, tied to the account, and a Package key, tied 
 
 Note that the APIs for mobile and residential packages differ a bit.
 
-#### Get list of mobile carriers
+### Get list of mobile carriers
 
 This is for Mobile packages only.
 
@@ -83,7 +81,7 @@ $ curl "https://api.soax.com/api/get-country-operators?api_key=$SOAX_API_KEY&pac
 ["pjsc megafon","mts pjsc","tele2 russia","beeline","rostelecom","jsc ufanet","edinos","ekaterinburg-2000","tbank jsc","er-telecom","t-mob","mcs","dom.ru","sberbank-telecom","llc sp abaza telecom","s.u.e. dpr republic operator of networks","tattelecom","edinos ltd.","invest mobile","isp balzer-telecom","innovation solutions center ltd.","novokuznetsk telecom","mobile trend","ooo network of data-centers selectel","dagnet","jv a-mobile","llc alfa-mobile","zao aquafon-gsm","ooo vtc-mobile"]
 ```
 
-#### Get list of residential ISPS
+### Get list of residential ISPS
 
 This is for Residential packages only. The official documentation refers to them as "WiFi ISPS".
 
@@ -95,7 +93,7 @@ Request format:
 https://api.soax.com/api/get-country-isp?api_key=<api_key>&package_key=<package_key>&country_iso=<country_iso>[&region=<region_name>[&city=<city_name>]]
 ```
 
-#### Get list of regions
+### Get list of regions
 
 [Reference](https://helpcenter.soax.com/en/articles/6227864-getting-a-list-of-regions)
 
@@ -115,7 +113,7 @@ $ curl  "https://api.soax.com/api/get-country-regions?api_key=$SOAX_API_KEY&pack
 ["tehran","razavi khorasan","fars","isfahan","khuzestan","east azerbaijan province","alborz province","mazandaran","west azerbaijan province","gilan province","qom province"]
 ```
 
-#### Get list of cities
+### Get list of cities
 
 [Reference](https://helpcenter.soax.com/en/articles/6228092-getting-a-list-of-cities)
 

--- a/x/soax/README.md
+++ b/x/soax/README.md
@@ -38,7 +38,7 @@ $ curl --proxy "socks5h://package-${SOAX_PACKAGE_ID}-country-de-isp-o2+deutschla
 Here is the same request using HTTP CONNECT:
 
 ```console
-$curl --proxy "https://package-${SOAX_PACKAGE_ID}-country-de-isp-o2+deutschland:${SOAX_PACKAGE_KEY}@proxy.soax.com:5000" https://checker.soax.com/api/ipinfo 
+$ curl --proxy "https://package-${SOAX_PACKAGE_ID}-country-de-isp-o2+deutschland:${SOAX_PACKAGE_KEY}@proxy.soax.com:5000" https://checker.soax.com/api/ipinfo 
 
 {"status":true,"reason":"","data":{"carrier":"O2 Deutschland","city":"Wuppertal","country_code":"DE","country_name":"Germany","ip":"176.1.206.77","isp":"O2 Deutschland","region":"North Rhine-Westphalia"}}
 ```

--- a/x/soax/api.go
+++ b/x/soax/api.go
@@ -1,0 +1,182 @@
+// Copyright 2025 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package soax
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const (
+	apiHost = "api.soax.com"
+)
+
+// ConnType specifies the connection type for SOAX API calls.
+type ConnType string
+
+const (
+	// ConnTypeResidential is for residential proxies, referred to as "wifi" by the API.
+	ConnTypeResidential ConnType = "wifi"
+	// ConnTypeMobile is for mobile proxies.
+	ConnTypeMobile ConnType = "mobile"
+)
+
+// Client allows you to access the SOAX REST API.
+type Client struct {
+	APIKey     string
+	PackageKey string
+	// ConnType is the connection type.
+	ConnType ConnType
+	// HTTPClient is the client to use for API calls. If nil, a default client will be used.
+	HTTPClient *http.Client
+	// BaseURL for testing. If empty, "https://api.soax.com" is used. This can be a plain URL, or one
+	// with a path.
+	BaseURL string
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient == nil {
+		return http.DefaultClient
+	}
+	return c.HTTPClient
+}
+
+func (c *Client) newRequest(ctx context.Context, apiPath string, queryParams map[string]string) (*http.Request, error) {
+	var baseURL *url.URL
+	var err error
+	if c.BaseURL != "" {
+		baseURL, err = url.Parse(c.BaseURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse BaseURL: %w", err)
+		}
+	} else {
+		baseURL = &url.URL{
+			Scheme: "https",
+			Host:   apiHost,
+		}
+	}
+	pathURL := &url.URL{Path: apiPath}
+	apiURL := baseURL.ResolveReference(pathURL)
+
+	q := apiURL.Query()
+	q.Set("api_key", c.APIKey)
+	q.Set("package_key", c.PackageKey)
+	for k, v := range queryParams {
+		if v != "" {
+			q.Set(k, v)
+		}
+	}
+	apiURL.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	return req, nil
+}
+
+func (c *Client) doAndDecode(req *http.Request, result any) error {
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("request failed with status %v: %v", resp.Status, string(body))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+	return nil
+}
+
+// GetResidentialISPs returns the available ISPs for the given location.
+// This is for Residential packages only. The official documentation refers to them as "WiFi ISPS".
+// API reference: https://helpcenter.soax.com/en/articles/6228391-getting-a-list-of-wifi-isps
+func (c *Client) GetResidentialISPs(ctx context.Context, countryCode, regionID, cityID string) ([]string, error) {
+	req, err := c.newRequest(ctx, "/api/get-country-isp", map[string]string{
+		"country_iso": countryCode,
+		"region":      regionID,
+		"city":        cityID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var isps []string
+	if err := c.doAndDecode(req, &isps); err != nil {
+		return nil, err
+	}
+	return isps, nil
+}
+
+// GetMobileISPs returns the available mobile carriers for the given location.
+// This is for Mobile packages only.
+// API reference: https://helpcenter.soax.com/en/articles/6228381-getting-a-list-of-mobile-carriers
+func (c *Client) GetMobileISPs(ctx context.Context, countryCode, regionID, cityID string) ([]string, error) {
+	req, err := c.newRequest(ctx, "/api/get-country-operators", map[string]string{
+		"country_iso": countryCode,
+		"region":      regionID,
+		"city":        cityID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var isps []string
+	if err := c.doAndDecode(req, &isps); err != nil {
+		return nil, err
+	}
+	return isps, nil
+}
+
+// GetRegions returns the available regions for the given country and ISP.
+// API reference: https://helpcenter.soax.com/en/articles/6227864-getting-a-list-of-regions
+func (c *Client) GetRegions(ctx context.Context, countryCode, isp string) ([]string, error) {
+	req, err := c.newRequest(ctx, "/api/get-country-regions", map[string]string{
+		"country_iso": countryCode,
+		"conn_type":   string(c.ConnType),
+		"provider":    isp,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var regions []string
+	if err := c.doAndDecode(req, &regions); err != nil {
+		return nil, err
+	}
+	return regions, nil
+}
+
+// GetCities returns the available cities for the given country, ISP, and region.
+// API reference: https://helpcenter.soax.com/en/articles/6228092-getting-a-list-of-cities
+func (c *Client) GetCities(ctx context.Context, countryCode, isp, regionID string) ([]string, error) {
+	req, err := c.newRequest(ctx, "/api/get-country-cities", map[string]string{
+		"country_iso": countryCode,
+		"conn_type":   string(c.ConnType),
+		"provider":    isp,
+		"region":      regionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var cities []string
+	if err := c.doAndDecode(req, &cities); err != nil {
+		return nil, err
+	}
+	return cities, nil
+}

--- a/x/soax/api_test.go
+++ b/x/soax/api_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package soax
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient(t *testing.T) {
+	const (
+		testAPIKey     = "test_api_key"
+		testPackageKey = "test_package_key"
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		q := r.URL.Query()
+		require.Equal(t, testAPIKey, q.Get("api_key"))
+		require.Equal(t, testPackageKey, q.Get("package_key"))
+
+		var responseData any
+		switch r.URL.Path {
+		case "/api/get-country-isp":
+			require.Equal(t, "us", q.Get("country_iso"))
+			require.Equal(t, "ny", q.Get("region"))
+			require.Equal(t, "nyc", q.Get("city"))
+			responseData = []string{"isp1", "isp2"}
+		case "/api/get-country-operators":
+			require.Equal(t, "de", q.Get("country_iso"))
+			require.Equal(t, "be", q.Get("region"))
+			require.Equal(t, "ber", q.Get("city"))
+			responseData = []string{"op1", "op2"}
+		case "/api/get-country-regions":
+			require.Equal(t, "fr", q.Get("country_iso"))
+			require.Equal(t, "mobile", q.Get("conn_type"))
+			require.Equal(t, "orange", q.Get("provider"))
+			responseData = []string{"region1", "region2"}
+		case "/api/get-country-cities":
+			require.Equal(t, "es", q.Get("country_iso"))
+			require.Equal(t, "wifi", q.Get("conn_type"))
+			require.Equal(t, "movistar", q.Get("provider"))
+			require.Equal(t, "md", q.Get("region"))
+			responseData = []string{"city1", "city2"}
+		default:
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(responseData)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		APIKey:     testAPIKey,
+		PackageKey: testPackageKey,
+		HTTPClient: server.Client(),
+		BaseURL:    server.URL,
+	}
+
+	ctx := context.Background()
+
+	t.Run("GetResidentialISPs", func(t *testing.T) {
+		isps, err := client.GetResidentialISPs(ctx, "us", "ny", "nyc")
+		require.NoError(t, err)
+		require.Equal(t, []string{"isp1", "isp2"}, isps)
+	})
+
+	t.Run("GetMobileISPs", func(t *testing.T) {
+		isps, err := client.GetMobileISPs(ctx, "de", "be", "ber")
+		require.NoError(t, err)
+		require.Equal(t, []string{"op1", "op2"}, isps)
+	})
+
+	t.Run("GetRegions", func(t *testing.T) {
+		client.ConnType = ConnTypeMobile
+		regions, err := client.GetRegions(ctx, "fr", "orange")
+		require.NoError(t, err)
+		require.Equal(t, []string{"region1", "region2"}, regions)
+	})
+
+	t.Run("GetCities", func(t *testing.T) {
+		client.ConnType = ConnTypeResidential
+		cities, err := client.GetCities(ctx, "es", "movistar", "md")
+		require.NoError(t, err)
+		require.Equal(t, []string{"city1", "city2"}, cities)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		errorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}))
+		defer errorServer.Close()
+		errorClient := &Client{
+			APIKey:     testAPIKey,
+			PackageKey: testPackageKey,
+			HTTPClient: errorServer.Client(),
+			BaseURL:    errorServer.URL,
+		}
+		_, err := errorClient.GetResidentialISPs(ctx, "us", "ny", "nyc")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "request failed with status 500 Internal Server Error")
+		require.Contains(t, err.Error(), "internal server error")
+	})
+
+	t.Run("BadJSON", func(t *testing.T) {
+		badJSONServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{"bad json`))
+			require.NoError(t, err)
+		}))
+		defer badJSONServer.Close()
+		badJSONClient := &Client{
+			APIKey:     testAPIKey,
+			PackageKey: testPackageKey,
+			HTTPClient: badJSONServer.Client(),
+			BaseURL:    badJSONServer.URL,
+		}
+		_, err := badJSONClient.GetResidentialISPs(ctx, "us", "ny", "nyc")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode response")
+	})
+}

--- a/x/soax/proxy.go
+++ b/x/soax/proxy.go
@@ -1,0 +1,139 @@
+// Copyright 2025 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package soax
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+	"github.com/Jigsaw-Code/outline-sdk/transport/socks5"
+	"github.com/Jigsaw-Code/outline-sdk/x/httpconnect"
+)
+
+const (
+	proxyAddress = "proxy.soax.com:5000"
+)
+
+// SessionConfig defines how to connect to the SOAX proxy.
+type SessionConfig struct {
+	// Credentials
+	PackageID  int
+	PackageKey string
+
+	// Restrictions
+	CountryCode string
+	RegionID    string
+	CityID      string
+	ISPID       string
+
+	// Session management
+	SessionID     string
+	SessionLength time.Duration
+	IdleTTL       time.Duration
+
+	// Endpoint address. If empty, defaults to proxy.soax.com:5000.
+	// Useful for testing or reverse proxies.
+	Endpoint string
+}
+
+// Session represents a session with unique SessionID, created from a SessionConfig.
+type Session struct {
+	config *SessionConfig
+}
+
+func (c *SessionConfig) newUserPassword() *url.Userinfo {
+	params := []string{"package", strconv.Itoa(c.PackageID)}
+	if c.CountryCode != "" {
+		params = append(params, "country", strings.ToLower(c.CountryCode))
+	}
+	if c.RegionID != "" {
+		params = append(params, "region", c.RegionID)
+	}
+	if c.CityID != "" {
+		params = append(params, "city", c.CityID)
+	}
+	if c.ISPID != "" {
+		params = append(params, "isp", c.ISPID)
+	}
+	if c.SessionID != "" {
+		params = append(params, "sessionid", c.SessionID)
+	}
+	if c.SessionLength > 0 {
+		params = append(params, "sessionlength", strconv.Itoa(int(c.SessionLength.Seconds())))
+	}
+	if c.IdleTTL > 0 {
+		params = append(params, "idlettl", strconv.Itoa(int(c.IdleTTL.Seconds())))
+	}
+	return url.UserPassword(strings.Join(params, "-"), c.PackageKey)
+}
+
+func (c *SessionConfig) NewSession() *Session {
+	session := new(Session)
+	// Copy the config to not modify the original one.
+	session.config = c
+	if session.config.SessionID == "" {
+		session.config.SessionID = strconv.Itoa(int(time.Now().UnixMilli()))
+	}
+	if session.config.SessionLength == 0 {
+		// 1 hour is the maximum session length as per
+		// https://helpcenter.soax.com/en/articles/9925415-building-sticky-sessions-connection
+		session.config.SessionLength = 1 * time.Hour
+	}
+	if session.config.IdleTTL == 0 {
+		// Ensure IPs won't be released if they become idle during the session as per
+		// https://helpcenter.soax.com/en/articles/9939557-understanding-session-parameters#h_ffc53ee8d5
+		session.config.IdleTTL = session.config.SessionLength
+	}
+	if session.config.Endpoint == "" {
+		session.config.Endpoint = proxyAddress
+	}
+	return session
+}
+
+// NewSOCKS5Client creates a [socks5.Client] that connects through the SOAX proxy.
+func (c *Session) NewSOCKS5Client() (*socks5.Client, error) {
+	client, err := socks5.NewClient(&transport.TCPEndpoint{Address: c.config.Endpoint})
+	if err != nil {
+		return nil, err
+	}
+	client.EnablePacket(&transport.UDPDialer{})
+	userinfo := c.config.newUserPassword()
+	password, _ := userinfo.Password()
+	client.SetCredentials([]byte(userinfo.Username()), []byte(password))
+	return client, nil
+}
+
+// NewStreamDialer creates a [transport.StreamDialer] that connects through the SOAX proxy.
+// It uses HTTP CONNECT, so it only supports TCP.
+func (c *Session) NewWebProxyStreamDialer() (transport.StreamDialer, error) {
+	rt, err := httpconnect.NewHTTPProxyTransport(&transport.TCPDialer{}, c.config.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	b64EncodedCredentials := base64.StdEncoding.EncodeToString([]byte(c.config.newUserPassword().String()))
+	return httpconnect.NewConnectClient(rt,
+		httpconnect.WithHeaders(http.Header{
+			"Proxy-Authorization": {fmt.Sprintf("Basic %s", b64EncodedCredentials)},
+			// TODO: Add support for Respond-With, as explained in
+			// https://helpcenter.soax.com/en/articles/9956908-getting-node-information-with-the-respond-with-header
+		}),
+	)
+}

--- a/x/soax/proxy_test.go
+++ b/x/soax/proxy_test.go
@@ -1,0 +1,137 @@
+// Copyright 2025 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package soax
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/things-go/go-socks5"
+)
+
+func TestSessionConfig_newUsername_AllFields(t *testing.T) {
+	config := SessionConfig{
+		PackageID:     123456,
+		PackageKey:    "my_package_key",
+		CountryCode:   "us",
+		RegionID:      "new york",
+		CityID:        "new york city",
+		ISPID:         "verizon",
+		SessionID:     "my_session",
+		SessionLength: 10 * time.Minute,
+		IdleTTL:       5 * time.Minute,
+	}
+	userinfo := config.newUserPassword()
+	require.Equal(t,
+		"package-123456-country-us-region-new%20york-city-new%20york%20city-isp-verizon-sessionid-my_session-sessionlength-600-idlettl-300:my_package_key",
+		userinfo.String())
+	require.Equal(t, "package-123456-country-us-region-new york-city-new york city-isp-verizon-sessionid-my_session-sessionlength-600-idlettl-300", userinfo.Username())
+	password, isSet := userinfo.Password()
+	require.True(t, isSet)
+	require.Equal(t, "my_package_key", password)
+}
+
+func TestSessionConfig_newUsername_PackageOnly(t *testing.T) {
+	config := SessionConfig{
+		PackageID:  123456,
+		PackageKey: "my_package_key",
+	}
+	require.Equal(t, "package-123456:my_package_key", config.newUserPassword().String())
+}
+
+func TestSessionConfig_newSession_SetsDefaults(t *testing.T) {
+	config := SessionConfig{
+		PackageID:  123456,
+		PackageKey: "my_package_key",
+	}
+	session := config.NewSession()
+	require.NotNil(t, session)
+	require.NotContains(t, session.config.SessionID, "-")
+	require.NotEmpty(t, session.config.SessionID)
+	require.Equal(t, 1*time.Hour, session.config.SessionLength)
+	require.Equal(t, 1*time.Hour, session.config.IdleTTL)
+	require.Equal(t, proxyAddress, session.config.Endpoint)
+}
+
+type FuncCredentialStore func(user, password, userAddr string) bool
+
+func (f FuncCredentialStore) Valid(user, password, userAddr string) bool {
+	return f(user, password, userAddr)
+}
+
+var _ socks5.CredentialStore = FuncCredentialStore(nil)
+
+func TestSession_NewSOCKS5Client(t *testing.T) {
+	config := SessionConfig{
+		PackageID:  123456,
+		PackageKey: "my_package_key",
+	}
+	var userinfo url.Userinfo
+
+	// Create a SOCKS5 server that expects the credentials from the config.
+	cator := socks5.UserPassAuthenticator{
+		Credentials: FuncCredentialStore(func(userToCheck, passwordToCheck, userAddr string) bool {
+			require.Equal(t, userinfo.Username(), userToCheck)
+			expectedPassword, _ := userinfo.Password()
+			require.Equal(t, expectedPassword, passwordToCheck)
+			return true
+		}),
+	}
+	server := socks5.NewServer(
+		socks5.WithAuthMethods([]socks5.Authenticator{cator}),
+	)
+
+	var running sync.WaitGroup
+	// Create SOCKS5 proxy on localhost with a random port.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	running.Add(1)
+	go func() {
+		defer running.Done()
+		err := server.Serve(listener)
+		// The server will be stopped by closing the listener.
+		if err != nil && !errors.Is(err, net.ErrClosed) {
+			require.NoError(t, err)
+		}
+	}()
+	defer func() {
+		listener.Close()
+		running.Wait()
+	}()
+
+	// The SOCKS5 server from things-go/go-socks5 will try to connect to this address.
+	// We need a listener, otherwise the Dial will fail with connection refused.
+	targetListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer targetListener.Close()
+
+	// Set the endpoint to our test server.
+	config.Endpoint = listener.Addr().String()
+	session := config.NewSession()
+	userinfo = *session.config.newUserPassword()
+	client, err := session.NewSOCKS5Client()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	_, err = client.DialStream(context.Background(), targetListener.Addr().String())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This creates a library to use SOAX in Go.
I intend to use it for measurements later. The API may change once I actually use it.

This also works as helpful documentation for using SOAX.