### PR TITLE
feat: add GEMINI.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,10 @@ go tool pkgsite -dev
 
 Then open http://localhost:8080 on your browser. The `-dev` flag is optional and enables developer mode, reloading content on changes.
 
+## Style
+
+We use the standard Go style. Use `gofmt -w <path>` tool to make sure the style is correct.
+
 ## Cross-platform Development
 
 ### Building

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+CONTRIBUTING.md


### PR DESCRIPTION
This makes Gemini on VSCode actually read the `CONTRIBUTORS.md`. It doesn't currently read `AGENTS.md` (though Jules does).

I also added a note about style so they fix the style on changes.
