### PR TITLE
feat(x): psiphon.Start should succeed even it it's already been started

### DIFF
--- a/x/psiphon/psiphon.go
+++ b/x/psiphon/psiphon.go
@@ -199,6 +199,18 @@ func (d *Dialer) Stop() error {
 	return nil
 }
 
+// If the dialer has not yet started, starts it.
+// If the dialer is already started, stop it and restart with the new config
+// TODO: if the dialer is already started and config is identical, just return nil
+func (d *Dialer) StartOrRestart(startCtx context.Context, config *DialerConfig) error {
+	err := d.Start(startCtx, config)
+	if err == errAlreadyStarted {
+		err = d.Stop()
+		err = d.Start(startCtx, config)
+	}
+	return err
+}
+
 // GetSingletonDialer returns the single Psiphon dialer instance.
 func GetSingletonDialer() *Dialer {
 	return &singletonDialer

--- a/x/psiphon/psiphon.go
+++ b/x/psiphon/psiphon.go
@@ -208,7 +208,7 @@ func (d *Dialer) Start(startCtx context.Context, config *DialerConfig) error {
 		// If the dialer is already started, stop it and restart with the new config
 		err = d.Stop()
 		if err != nil {
-			return err
+			return errors.Join(errAlreadyStarted, err)
 		}
 		err = d.startHelper(startCtx, config)
 		// TODO: if the dialer is already started and config is identical, just return nil

--- a/x/psiphon/psiphon.go
+++ b/x/psiphon/psiphon.go
@@ -120,9 +120,10 @@ func psiphonStartTunnel(tunnelCtx context.Context, config *DialerConfig) (psipho
 	return clientlib.StartTunnel(tunnelCtx, config.ProviderConfig, "", params, nil, nil)
 }
 
+// Helper function for Start which encapsulates the mutex call.
 // Starts running the Dialer. It returns when the tunnel is ready.
 // If the dialer is already started returns errAlreadyStarted
-func (d *Dialer) startDialer(startCtx context.Context, config *DialerConfig) error {
+func (d *Dialer) startHelper(startCtx context.Context, config *DialerConfig) error {
 	resultCh := make(chan error)
 	go func() {
 		d.mu.Lock()
@@ -202,14 +203,14 @@ func (d *Dialer) Stop() error {
 
 // Start configures and runs the Dialer. It must be called before you can use the Dialer. It returns when the tunnel is ready.
 func (d *Dialer) Start(startCtx context.Context, config *DialerConfig) error {
-	err := d.startDialer(startCtx, config)
+	err := d.startHelper(startCtx, config)
 	if err == errAlreadyStarted {
 		// If the dialer is already started, stop it and restart with the new config
 		err = d.Stop()
 		if err != nil {
 			return err
 		}
-		err = d.startDialer(startCtx, config)
+		err = d.startHelper(startCtx, config)
 		// TODO: if the dialer is already started and config is identical, just return nil
 	}
 	return err

--- a/x/psiphon/psiphon_test.go
+++ b/x/psiphon/psiphon_test.go
@@ -88,8 +88,6 @@ func TestDialer_StopOnStart(t *testing.T) {
 
 // Test that there's no race condition if you call start while start is running
 func TestDialer_StartOnStart(t *testing.T) {
-	//failedToStartError := errors.New("failed to start")
-
 	dialer := GetSingletonDialer()
 	dialer.Start(context.Background(), nil)
 

--- a/x/psiphon/psiphon_test.go
+++ b/x/psiphon/psiphon_test.go
@@ -142,6 +142,29 @@ func TestDialer_Start_Timeout(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestDialer_StartOrRestart_Successful(t *testing.T) {
+	dialer := GetSingletonDialer()
+	startTunnel = func(ctx context.Context, config *DialerConfig) (psiphonTunnel, error) {
+		return &clientlib.PsiphonTunnel{}, nil
+	}
+	defer func() {
+		startTunnel = psiphonStartTunnel
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, dialer.StartOrRestart(ctx, nil))
+	require.NoError(t, dialer.StartOrRestart(ctx, nil))
+	require.NoError(t, dialer.Stop())
+
+	// StartOrRestart after Start
+	require.NoError(t, dialer.Start(ctx, nil))
+	require.NoError(t, dialer.StartOrRestart(ctx, nil))
+	require.NoError(t, dialer.Stop())
+
+}
+
 type errorTunnel struct {
 	err     error
 	stopped bool

--- a/x/psiphon/psiphon_test.go
+++ b/x/psiphon/psiphon_test.go
@@ -54,7 +54,8 @@ func TestDialer_Start_Successful(t *testing.T) {
 	defer cancel()
 	require.NoError(t, dialer.Start(ctx, nil))
 	require.NotNil(t, dialer.tunnel)
-	require.ErrorIs(t, dialer.Start(ctx, nil), errAlreadyStarted)
+	// we can restart an already-started dialer with no error
+	require.NoError(t, dialer.Start(ctx, nil))
 	require.NoError(t, dialer.Stop())
 	require.Nil(t, dialer.tunnel)
 	require.ErrorIs(t, dialer.Stop(), errNotStartedStop)
@@ -85,9 +86,15 @@ func TestDialer_StopOnStart(t *testing.T) {
 	require.Error(t, <-resultCh)
 }
 
+// Test that there's no race condition if you call start while start is running
 func TestDialer_StartOnStart(t *testing.T) {
+	//failedToStartError := errors.New("failed to start")
+
 	dialer := GetSingletonDialer()
+	dialer.Start(context.Background(), nil)
+
 	startCalled := make(chan struct{})
+	// Long running startTunnel
 	startTunnel = func(ctx context.Context, config *DialerConfig) (psiphonTunnel, error) {
 		startCalled <- struct{}{}
 		select {
@@ -104,10 +111,16 @@ func TestDialer_StartOnStart(t *testing.T) {
 		resultCh <- dialer.Start(context.Background(), nil)
 	}()
 	<-startCalled
+
+	// Normal startTunnel
 	startTunnel = func(ctx context.Context, config *DialerConfig) (psiphonTunnel, error) {
-		return nil, errors.New("failed to start")
+		return &clientlib.PsiphonTunnel{}, nil
 	}
-	require.ErrorIs(t, dialer.Start(context.Background(), nil), errAlreadyStarted)
+	defer func() {
+		startTunnel = psiphonStartTunnel
+	}()
+
+	require.NoError(t, dialer.Start(context.Background(), nil))
 	require.NoError(t, dialer.Stop())
 	require.Error(t, <-resultCh)
 }
@@ -140,29 +153,6 @@ func TestDialer_Start_Timeout(t *testing.T) {
 	}()
 	err := <-errCh
 	require.ErrorIs(t, err, context.Canceled)
-}
-
-func TestDialer_StartOrRestart_Successful(t *testing.T) {
-	dialer := GetSingletonDialer()
-	startTunnel = func(ctx context.Context, config *DialerConfig) (psiphonTunnel, error) {
-		return &clientlib.PsiphonTunnel{}, nil
-	}
-	defer func() {
-		startTunnel = psiphonStartTunnel
-	}()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	require.NoError(t, dialer.StartOrRestart(ctx, nil))
-	require.NoError(t, dialer.StartOrRestart(ctx, nil))
-	require.NoError(t, dialer.Stop())
-
-	// StartOrRestart after Start
-	require.NoError(t, dialer.Start(ctx, nil))
-	require.NoError(t, dialer.StartOrRestart(ctx, nil))
-	require.NoError(t, dialer.Stop())
-
 }
 
 type errorTunnel struct {

--- a/x/smart/psiphon_dialer.go
+++ b/x/smart/psiphon_dialer.go
@@ -24,7 +24,7 @@ func newPsiphonDialer(finder *StrategyFinder, ctx context.Context, psiphonJSON [
 	config.DataRootDirectory = userCacheDir
 
 	dialer := psiphon.GetSingletonDialer()
-	if err := dialer.Start(ctx, config); err != nil {
+	if err := dialer.StartOrRestart(ctx, config); err != nil {
 		return nil, fmt.Errorf("failed to start psiphon dialer: %w", err)
 	}
 

--- a/x/smart/psiphon_dialer.go
+++ b/x/smart/psiphon_dialer.go
@@ -24,7 +24,7 @@ func newPsiphonDialer(finder *StrategyFinder, ctx context.Context, psiphonJSON [
 	config.DataRootDirectory = userCacheDir
 
 	dialer := psiphon.GetSingletonDialer()
-	if err := dialer.StartOrRestart(ctx, config); err != nil {
+	if err := dialer.Start(ctx, config); err != nil {
 		return nil, fmt.Errorf("failed to start psiphon dialer: %w", err)
 	}
 


### PR DESCRIPTION
Modifies `psiphon.Start` to psiphon to deal with environments (like an android app stopping and resuming) where the psiphon singleton may have already been started.