### PR TITLE
feat(x): make Psiphon Start supersede previous Start

### DIFF
--- a/x/psiphon/psiphon.go
+++ b/x/psiphon/psiphon.go
@@ -128,8 +128,13 @@ func (d *Dialer) Start(startCtx context.Context, config *DialerConfig) error {
 		defer d.mu.Unlock()
 
 		if d.stop != nil {
-			resultCh <- errAlreadyStarted
-			return
+			// If we are already started stop first
+			// We can't check for errors here since d.stop() doesn't return errors
+			stop := d.stop
+			d.stop = nil
+			d.mu.Unlock()
+			stop()
+			d.mu.Lock()
 		}
 
 		// startCtx is intended for the lifetime of the startup.

--- a/x/psiphon/psiphon.go
+++ b/x/psiphon/psiphon.go
@@ -128,10 +128,10 @@ func (d *Dialer) Start(startCtx context.Context, config *DialerConfig) error {
 		defer d.mu.Unlock()
 
 		if d.stop != nil {
-			// If we are already started stop first
-			// We can't check for errors here since d.stop() doesn't return errors
+			// If we are already started stop first.
 			stop := d.stop
 			d.stop = nil
+			// Make sure we unlock the mutex so that the previous Start can complete.
 			d.mu.Unlock()
 			stop()
 			d.mu.Lock()


### PR DESCRIPTION
Make `psiphon.Start` supersede a previous Start call. We have seen cases on Android where start was being called again without the dialer being stopped first.

Replaces https://github.com/Jigsaw-Code/outline-sdk/pull/523