### PR TITLE
refactor(x): normalize API codes for SOAX

### DIFF
--- a/x/soax/api.go
+++ b/x/soax/api.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const (
@@ -115,7 +116,7 @@ func (c *Client) doAndDecode(req *http.Request, result any) error {
 // API reference: https://helpcenter.soax.com/en/articles/6228391-getting-a-list-of-wifi-isps
 func (c *Client) GetResidentialISPs(ctx context.Context, countryCode, regionID, cityID string) ([]string, error) {
 	req, err := c.newRequest(ctx, "/api/get-country-isp", map[string]string{
-		"country_iso": countryCode,
+		"country_iso": strings.ToLower(countryCode),
 		"region":      regionID,
 		"city":        cityID,
 	})
@@ -134,7 +135,7 @@ func (c *Client) GetResidentialISPs(ctx context.Context, countryCode, regionID, 
 // API reference: https://helpcenter.soax.com/en/articles/6228381-getting-a-list-of-mobile-carriers
 func (c *Client) GetMobileISPs(ctx context.Context, countryCode, regionID, cityID string) ([]string, error) {
 	req, err := c.newRequest(ctx, "/api/get-country-operators", map[string]string{
-		"country_iso": countryCode,
+		"country_iso": strings.ToLower(countryCode),
 		"region":      regionID,
 		"city":        cityID,
 	})
@@ -152,7 +153,7 @@ func (c *Client) GetMobileISPs(ctx context.Context, countryCode, regionID, cityI
 // API reference: https://helpcenter.soax.com/en/articles/6227864-getting-a-list-of-regions
 func (c *Client) GetRegions(ctx context.Context, countryCode, isp string) ([]string, error) {
 	req, err := c.newRequest(ctx, "/api/get-country-regions", map[string]string{
-		"country_iso": countryCode,
+		"country_iso": strings.ToLower(countryCode),
 		"conn_type":   string(c.ConnType),
 		"provider":    isp,
 	})
@@ -170,7 +171,7 @@ func (c *Client) GetRegions(ctx context.Context, countryCode, isp string) ([]str
 // API reference: https://helpcenter.soax.com/en/articles/6228092-getting-a-list-of-cities
 func (c *Client) GetCities(ctx context.Context, countryCode, isp, regionID string) ([]string, error) {
 	req, err := c.newRequest(ctx, "/api/get-country-cities", map[string]string{
-		"country_iso": countryCode,
+		"country_iso": strings.ToLower(countryCode),
 		"conn_type":   string(c.ConnType),
 		"provider":    isp,
 		"region":      regionID,

--- a/x/soax/api_test.go
+++ b/x/soax/api_test.go
@@ -80,27 +80,27 @@ func TestClient(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("GetResidentialISPs", func(t *testing.T) {
-		isps, err := client.GetResidentialISPs(ctx, "us", "ny", "nyc")
+		isps, err := client.GetResidentialISPs(ctx, "US", "ny", "nyc")
 		require.NoError(t, err)
 		require.Equal(t, []string{"isp1", "isp2"}, isps)
 	})
 
 	t.Run("GetMobileISPs", func(t *testing.T) {
-		isps, err := client.GetMobileISPs(ctx, "de", "be", "ber")
+		isps, err := client.GetMobileISPs(ctx, "DE", "be", "ber")
 		require.NoError(t, err)
 		require.Equal(t, []string{"op1", "op2"}, isps)
 	})
 
 	t.Run("GetRegions", func(t *testing.T) {
 		client.ConnType = ConnTypeMobile
-		regions, err := client.GetRegions(ctx, "fr", "orange")
+		regions, err := client.GetRegions(ctx, "FR", "orange")
 		require.NoError(t, err)
 		require.Equal(t, []string{"region1", "region2"}, regions)
 	})
 
 	t.Run("GetCities", func(t *testing.T) {
 		client.ConnType = ConnTypeResidential
-		cities, err := client.GetCities(ctx, "es", "movistar", "md")
+		cities, err := client.GetCities(ctx, "ES", "movistar", "md")
 		require.NoError(t, err)
 		require.Equal(t, []string{"city1", "city2"}, cities)
 	})

--- a/x/soax/proxy_test.go
+++ b/x/soax/proxy_test.go
@@ -34,7 +34,7 @@ func TestSessionConfig_newUsername_AllFields(t *testing.T) {
 			PackageKey: "my_package_key",
 		},
 		Node: ProxyNodeConfig{
-			CountryCode: "us",
+			CountryCode: "US",
 			RegionID:    "new york",
 			CityID:      "new york city",
 			ISPID:       "verizon",


### PR DESCRIPTION
The SOAX API requires lower case codes.

I also separated the read and parsing of the body so the errors are clearer.
Helpful for debugging