### PR TITLE
add access issue resolution instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,3 +272,11 @@ Downloaded 10.00 MB in 1.78s
 
 Downloaded Speed: 5.61 MB/s
 ```
+
+## Resolving Access Issues
+
+The Outline SDK go packages are accessed through the vanity Go URL `golang.getoutline.org`. If you experience [issues](https://github.com/OutlineFoundation/outline-sdk/issues/571) accessing this URL on your local network you can modify the commands to access the code through `proxy.golang.org`.
+
+```console
+sudo env GOPROXY=https://proxy.golang.org go run golang.getoutline.org/sdk/x/examples/outline-cli@latest
+```


### PR DESCRIPTION
Added good proxy advice per request in https://github.com/OutlineFoundation/outline-sdk/issues/571 for a user experiencing an access issue on our vanity URL.

Keeping this as a draft for now until the vanity URL / x package access issues are resolved. Since that makes verifying the exact correct command to run tricky.

