### PR TITLE
feat: Introduce dns.RawResolver interface

### DIFF
--- a/dns/doc.go
+++ b/dns/doc.go
@@ -45,5 +45,13 @@ in parallel, as per the [Happy Eyeballs v2] algorithm.
 [DNS-over-TLS]: https://datatracker.ietf.org/doc/html/rfc7858
 [DNS-over-HTTPS]: https://datatracker.ietf.org/doc/html/rfc8484
 [Happy Eyeballs v2]: https://datatracker.ietf.org/doc/html/rfc8305
+
+# RawResolver
+
+The [RawResolver] interface provides a lower-level primitive operating directly on wire-format byte arrays and primitive types (domain name, query type, and an output buffer). This design serves three main purposes:
+
+ 1. Zero-dependency footprint: Bypassing rigid DNS parsing libraries allows Outline to pack esoteric labels natively natively (e.g. obscure DNS tunneling headers).
+ 2. Future-proof compatibility: Callers can inject or parse the raw responses using any external library, including those supporting newer record types.
+ 3. Zero-allocation cycles: Providing a reusable `buf []byte` hands memory management to the caller, removing slice allocations in the hot path.
 */
 package dns

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -68,6 +68,40 @@ func (f FuncResolver) Query(ctx context.Context, q dnsmessage.Question) (*dnsmes
 	return f(ctx, q)
 }
 
+// RawResolver can query DNS and return the raw wire-format response bytes as defined in RFC 1035.
+// Using plain name and qtype avoids a dependency on any specific DNS parsing library,
+// allowing callers to parse the response with any library — including those that support
+// record types not yet recognized by golang.org/x/net/dns/dnsmessage.
+type RawResolver interface {
+	QueryRaw(ctx context.Context, name string, qtype uint16) ([]byte, error)
+}
+
+// FuncRawResolver is a [RawResolver] that uses the given function to query DNS.
+type FuncRawResolver func(ctx context.Context, name string, qtype uint16) ([]byte, error)
+
+// QueryRaw implements the [RawResolver] interface.
+func (f FuncRawResolver) QueryRaw(ctx context.Context, name string, qtype uint16) ([]byte, error) {
+	return f(ctx, name, qtype)
+}
+
+// RawToResolver wraps a [RawResolver] in a [Resolver] that parses the wire-format
+// response bytes using golang.org/x/net/dns/dnsmessage.
+// The underlying [RawResolver] is responsible for ID matching and returning valid bytes;
+// this adapter only unpacks the result.
+func RawToResolver(r RawResolver) Resolver {
+	return FuncResolver(func(ctx context.Context, q dnsmessage.Question) (*dnsmessage.Message, error) {
+		raw, err := r.QueryRaw(ctx, q.Name.String(), uint16(q.Type))
+		if err != nil {
+			return nil, err
+		}
+		var msg dnsmessage.Message
+		if err := msg.Unpack(raw); err != nil {
+			return nil, &nestedError{ErrBadResponse, fmt.Errorf("failed to unpack DNS response: %w", err)}
+		}
+		return &msg, nil
+	})
+}
+
 // NewQuestion is a convenience function to create a [dnsmessage.Question].
 // The input domain is interpreted as fully-qualified. If the end "." is missing, it's added.
 func NewQuestion(domain string, qtype dnsmessage.Type) (*dnsmessage.Question, error) {
@@ -92,6 +126,15 @@ func NewQuestion(domain string, qtype dnsmessage.Type) (*dnsmessage.Question, er
 // This is based on an MTU of 1280, which is required by the IPv6 specification, minus 48 bytes
 // for the IPv6 and UDP headers".
 const maxUDPMessageSize = 1232
+
+// makeQuestion constructs a dnsmessage.Question from a plain name and record type.
+func makeQuestion(name string, qtype uint16) (dnsmessage.Question, error) {
+	q, err := NewQuestion(name, dnsmessage.Type(qtype))
+	if err != nil {
+		return dnsmessage.Question{}, err
+	}
+	return *q, nil
+}
 
 // appendRequest appends the bytes a DNS request using the id and question to buf.
 func appendRequest(id uint16, q dnsmessage.Question, buf []byte) ([]byte, error) {
@@ -167,8 +210,13 @@ func checkResponse(reqID uint16, reqQues dnsmessage.Question, respHdr dnsmessage
 }
 
 // queryDatagram implements a DNS query over a datagram protocol.
-func queryDatagram(conn io.ReadWriter, q dnsmessage.Question) (*dnsmessage.Message, error) {
+// It validates the response ID and question echo before returning raw wire-format bytes.
+func queryDatagram(conn io.ReadWriter, name string, qtype uint16) ([]byte, error) {
 	// Reference: https://cs.opensource.google/go/go/+/master:src/net/dnsclient_unix.go?q=func:dnsPacketRoundTrip&ss=go%2Fgo
+	q, err := makeQuestion(name, qtype)
+	if err != nil {
+		return nil, &nestedError{ErrBadRequest, fmt.Errorf("invalid question: %w", err)}
+	}
 	id := uint16(rand.Uint32())
 	buf, err := appendRequest(id, q, make([]byte, 0, maxUDPMessageSize))
 	if err != nil {
@@ -198,17 +246,24 @@ func queryDatagram(conn io.ReadWriter, q dnsmessage.Question) (*dnsmessage.Messa
 			returnErr = errors.Join(returnErr, err)
 			continue
 		}
-		return &msg, nil
+		result := make([]byte, n)
+		copy(result, buf[:n])
+		return result, nil
 	}
 }
 
 // queryStream implements a DNS query over a stream protocol. It frames the messages by prepending them with a 2-byte length prefix.
-func queryStream(conn io.ReadWriter, q dnsmessage.Question) (*dnsmessage.Message, error) {
+// It validates the response ID and question echo before returning raw wire-format bytes.
+func queryStream(conn io.ReadWriter, name string, qtype uint16) ([]byte, error) {
 	// Reference: https://cs.opensource.google/go/go/+/master:src/net/dnsclient_unix.go?q=func:dnsStreamRoundTrip&ss=go%2Fgo
+	q, err := makeQuestion(name, qtype)
+	if err != nil {
+		return nil, &nestedError{ErrBadRequest, fmt.Errorf("invalid question: %w", err)}
+	}
 	id := uint16(rand.Uint32())
 	buf, err := appendRequest(id, q, make([]byte, 2, 514))
 	if err != nil {
-		return nil, &nestedError{ErrBadRequest, fmt.Errorf("append request failed: %w", err)}
+		return nil, &nestedError{ErrBadRequest, err}
 	}
 	// Buffer length must fit in a uint16.
 	if len(buf) > 1<<16-1 {
@@ -241,7 +296,7 @@ func queryStream(conn io.ReadWriter, q dnsmessage.Question) (*dnsmessage.Message
 	if err := checkResponse(id, q, msg.Header, msg.Questions); err != nil {
 		return nil, &nestedError{ErrBadResponse, err}
 	}
-	return &msg, nil
+	return buf, nil
 }
 
 func ensurePort(address string, defaultPort string) string {
@@ -256,13 +311,13 @@ func ensurePort(address string, defaultPort string) string {
 	return address
 }
 
-// NewUDPResolver creates a [Resolver] that implements the DNS-over-UDP protocol, using a [transport.PacketDialer] for transport.
+// NewUDPRawResolver creates a [RawResolver] that implements the DNS-over-UDP protocol, using a [transport.PacketDialer] for transport.
 // It uses a different port for every request.
 //
 // [DNS-over-UDP]: https://datatracker.ietf.org/doc/html/rfc1035#section-4.2.1
-func NewUDPResolver(pd transport.PacketDialer, resolverAddr string) Resolver {
+func NewUDPRawResolver(pd transport.PacketDialer, resolverAddr string) RawResolver {
 	resolverAddr = ensurePort(resolverAddr, "53")
-	return FuncResolver(func(ctx context.Context, q dnsmessage.Question) (*dnsmessage.Message, error) {
+	return FuncRawResolver(func(ctx context.Context, name string, qtype uint16) ([]byte, error) {
 		conn, err := pd.DialPacket(ctx, resolverAddr)
 		if err != nil {
 			return nil, &nestedError{ErrDial, err}
@@ -271,15 +326,23 @@ func NewUDPResolver(pd transport.PacketDialer, resolverAddr string) Resolver {
 		if deadline, ok := ctx.Deadline(); ok {
 			conn.SetDeadline(deadline)
 		}
-		return queryDatagram(conn, q)
+		return queryDatagram(conn, name, qtype)
 	})
 }
 
-type streamResolver struct {
+// NewUDPResolver creates a [Resolver] that implements the DNS-over-UDP protocol, using a [transport.PacketDialer] for transport.
+// It uses a different port for every request.
+//
+// [DNS-over-UDP]: https://datatracker.ietf.org/doc/html/rfc1035#section-4.2.1
+func NewUDPResolver(pd transport.PacketDialer, resolverAddr string) Resolver {
+	return RawToResolver(NewUDPRawResolver(pd, resolverAddr))
+}
+
+type streamRawResolver struct {
 	NewConn func(context.Context) (transport.StreamConn, error)
 }
 
-func (r *streamResolver) Query(ctx context.Context, q dnsmessage.Question) (*dnsmessage.Message, error) {
+func (r *streamRawResolver) QueryRaw(ctx context.Context, name string, qtype uint16) ([]byte, error) {
 	conn, err := r.NewConn(ctx)
 	if err != nil {
 		return nil, &nestedError{ErrDial, err}
@@ -289,7 +352,21 @@ func (r *streamResolver) Query(ctx context.Context, q dnsmessage.Question) (*dns
 	if deadline, ok := ctx.Deadline(); ok {
 		conn.SetDeadline(deadline)
 	}
-	return queryStream(conn, q)
+	return queryStream(conn, name, qtype)
+}
+
+// NewTCPRawResolver creates a [RawResolver] that implements the [DNS-over-TCP] protocol, using a [transport.StreamDialer] for transport.
+// It creates a new connection to the resolver for every request.
+//
+// [DNS-over-TCP]: https://datatracker.ietf.org/doc/html/rfc1035#section-4.2.2
+func NewTCPRawResolver(sd transport.StreamDialer, resolverAddr string) RawResolver {
+	// TODO: Consider handling Authenticated Data.
+	resolverAddr = ensurePort(resolverAddr, "53")
+	return &streamRawResolver{
+		NewConn: func(ctx context.Context) (transport.StreamConn, error) {
+			return sd.DialStream(ctx, resolverAddr)
+		},
+	}
 }
 
 // NewTCPResolver creates a [Resolver] that implements the [DNS-over-TCP] protocol, using a [transport.StreamDialer] for transport.
@@ -297,23 +374,17 @@ func (r *streamResolver) Query(ctx context.Context, q dnsmessage.Question) (*dns
 //
 // [DNS-over-TCP]: https://datatracker.ietf.org/doc/html/rfc1035#section-4.2.2
 func NewTCPResolver(sd transport.StreamDialer, resolverAddr string) Resolver {
-	// TODO: Consider handling Authenticated Data.
-	resolverAddr = ensurePort(resolverAddr, "53")
-	return &streamResolver{
-		NewConn: func(ctx context.Context) (transport.StreamConn, error) {
-			return sd.DialStream(ctx, resolverAddr)
-		},
-	}
+	return RawToResolver(NewTCPRawResolver(sd, resolverAddr))
 }
 
-// NewTLSResolver creates a [Resolver] that implements the [DNS-over-TLS] protocol, using a [transport.StreamDialer]
+// NewTLSRawResolver creates a [RawResolver] that implements the [DNS-over-TLS] protocol, using a [transport.StreamDialer]
 // to connect to the resolverAddr, and the resolverName as the TLS server name.
 // It creates a new connection to the resolver for every request.
 //
 // [DNS-over-TLS]: https://datatracker.ietf.org/doc/html/rfc7858
-func NewTLSResolver(sd transport.StreamDialer, resolverAddr string, resolverName string) Resolver {
+func NewTLSRawResolver(sd transport.StreamDialer, resolverAddr string, resolverName string) RawResolver {
 	resolverAddr = ensurePort(resolverAddr, "853")
-	return &streamResolver{
+	return &streamRawResolver{
 		NewConn: func(ctx context.Context) (transport.StreamConn, error) {
 			baseConn, err := sd.DialStream(ctx, resolverAddr)
 			if err != nil {
@@ -324,12 +395,21 @@ func NewTLSResolver(sd transport.StreamDialer, resolverAddr string, resolverName
 	}
 }
 
-// NewHTTPSResolver creates a [Resolver] that implements the [DNS-over-HTTPS] protocol, using a [transport.StreamDialer]
+// NewTLSResolver creates a [Resolver] that implements the [DNS-over-TLS] protocol, using a [transport.StreamDialer]
+// to connect to the resolverAddr, and the resolverName as the TLS server name.
+// It creates a new connection to the resolver for every request.
+//
+// [DNS-over-TLS]: https://datatracker.ietf.org/doc/html/rfc7858
+func NewTLSResolver(sd transport.StreamDialer, resolverAddr string, resolverName string) Resolver {
+	return RawToResolver(NewTLSRawResolver(sd, resolverAddr, resolverName))
+}
+
+// NewHTTPSRawResolver creates a [RawResolver] that implements the [DNS-over-HTTPS] protocol, using a [transport.StreamDialer]
 // to connect to the resolverAddr, and the url as the DoH template URI.
 // It uses an internal HTTP client that reuses connections when possible.
 //
 // [DNS-over-HTTPS]: https://datatracker.ietf.org/doc/html/rfc8484
-func NewHTTPSResolver(sd transport.StreamDialer, resolverAddr string, url string) Resolver {
+func NewHTTPSRawResolver(sd transport.StreamDialer, resolverAddr string, url string) RawResolver {
 	resolverAddr = ensurePort(resolverAddr, "443")
 	dialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
 		if !strings.HasPrefix(network, "tcp") {
@@ -352,11 +432,16 @@ func NewHTTPSResolver(sd transport.StreamDialer, resolverAddr string, url string
 			ResponseHeaderTimeout: 20 * time.Second, // Same value as Android DNS-over-TLS
 		},
 	}
-	return FuncResolver(func(ctx context.Context, q dnsmessage.Question) (*dnsmessage.Message, error) {
+	return FuncRawResolver(func(ctx context.Context, name string, qtype uint16) ([]byte, error) {
 		// Prepare request.
+		// DoH uses ID=0 per RFC 8484.
+		q, err := makeQuestion(name, qtype)
+		if err != nil {
+			return nil, &nestedError{ErrBadRequest, fmt.Errorf("invalid question: %w", err)}
+		}
 		buf, err := appendRequest(0, q, make([]byte, 0, 512))
 		if err != nil {
-			return nil, &nestedError{ErrBadRequest, fmt.Errorf("append request failed: %w", err)}
+			return nil, &nestedError{ErrBadRequest, err}
 		}
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(buf))
 		if err != nil {
@@ -388,6 +473,15 @@ func NewHTTPSResolver(sd transport.StreamDialer, resolverAddr string, url string
 		if err := checkResponse(0, q, msg.Header, msg.Questions); err != nil {
 			return nil, &nestedError{ErrBadResponse, err}
 		}
-		return &msg, nil
+		return response, nil
 	})
+}
+
+// NewHTTPSResolver creates a [Resolver] that implements the [DNS-over-HTTPS] protocol, using a [transport.StreamDialer]
+// to connect to the resolverAddr, and the url as the DoH template URI.
+// It uses an internal HTTP client that reuses connections when possible.
+//
+// [DNS-over-HTTPS]: https://datatracker.ietf.org/doc/html/rfc8484
+func NewHTTPSResolver(sd transport.StreamDialer, resolverAddr string, url string) Resolver {
+	return RawToResolver(NewHTTPSRawResolver(sd, resolverAddr, url))
 }

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -73,15 +73,15 @@ func (f FuncResolver) Query(ctx context.Context, q dnsmessage.Question) (*dnsmes
 // allowing callers to parse the response with any library — including those that support
 // record types not yet recognized by golang.org/x/net/dns/dnsmessage.
 type RawResolver interface {
-	QueryRaw(ctx context.Context, name string, qtype uint16) ([]byte, error)
+	QueryRaw(ctx context.Context, name string, qtype uint16, buf []byte) ([]byte, error)
 }
 
 // FuncRawResolver is a [RawResolver] that uses the given function to query DNS.
-type FuncRawResolver func(ctx context.Context, name string, qtype uint16) ([]byte, error)
+type FuncRawResolver func(ctx context.Context, name string, qtype uint16, buf []byte) ([]byte, error)
 
 // QueryRaw implements the [RawResolver] interface.
-func (f FuncRawResolver) QueryRaw(ctx context.Context, name string, qtype uint16) ([]byte, error) {
-	return f(ctx, name, qtype)
+func (f FuncRawResolver) QueryRaw(ctx context.Context, name string, qtype uint16, buf []byte) ([]byte, error) {
+	return f(ctx, name, qtype, buf)
 }
 
 // RawToResolver wraps a [RawResolver] in a [Resolver] that parses the wire-format
@@ -90,7 +90,8 @@ func (f FuncRawResolver) QueryRaw(ctx context.Context, name string, qtype uint16
 // this adapter only unpacks the result.
 func RawToResolver(r RawResolver) Resolver {
 	return FuncResolver(func(ctx context.Context, q dnsmessage.Question) (*dnsmessage.Message, error) {
-		raw, err := r.QueryRaw(ctx, q.Name.String(), uint16(q.Type))
+		buf := make([]byte, 0, maxUDPMessageSize)
+		raw, err := r.QueryRaw(ctx, q.Name.String(), uint16(q.Type), buf)
 		if err != nil {
 			return nil, err
 		}
@@ -127,41 +128,78 @@ func NewQuestion(domain string, qtype dnsmessage.Type) (*dnsmessage.Question, er
 // for the IPv6 and UDP headers".
 const maxUDPMessageSize = 1232
 
-// makeQuestion constructs a dnsmessage.Question from a plain name and record type.
-func makeQuestion(name string, qtype uint16) (dnsmessage.Question, error) {
-	q, err := NewQuestion(name, dnsmessage.Type(qtype))
-	if err != nil {
-		return dnsmessage.Question{}, err
+// appendName splits a dot-separated domain name into DNS wire-format labels and appends them to buf.
+func appendName(buf []byte, name string) ([]byte, error) {
+	if len(name) > 0 && name[len(name)-1] == '.' {
+		name = name[:len(name)-1]
 	}
-	return *q, nil
+	if len(name) == 0 {
+		return append(buf, 0), nil
+	}
+	startLength := len(buf)
+	for len(name) > 0 {
+		idx := strings.IndexByte(name, '.')
+		var label string
+		if idx == -1 {
+			label = name
+			name = ""
+		} else {
+			label = name[:idx]
+			name = name[idx+1:]
+		}
+		if len(label) == 0 {
+			return nil, errors.New("empty label")
+		}
+		if len(label) > 63 {
+			return nil, errors.New("label too long")
+		}
+		buf = append(buf, byte(len(label)))
+		buf = append(buf, label...)
+	}
+	buf = append(buf, 0)
+	if len(buf)-startLength > 255 {
+		return nil, errors.New("name too long")
+	}
+	return buf, nil
 }
 
-// appendRequest appends the bytes a DNS request using the id and question to buf.
-func appendRequest(id uint16, q dnsmessage.Question, buf []byte) ([]byte, error) {
-	b := dnsmessage.NewBuilder(buf, dnsmessage.Header{ID: id, RecursionDesired: true})
-	if err := b.StartQuestions(); err != nil {
-		return nil, fmt.Errorf("start questions failed: %w", err)
+// appendRequestRaw constructs a complete wire-format DNS request (Header, Question, OPT) and appends it to buf.
+func appendRequestRaw(id uint16, name string, qtype uint16, buf []byte) ([]byte, error) {
+	udpSize := uint16(cap(buf))
+	if udpSize < 512 {
+		udpSize = 512
 	}
-	if err := b.Question(q); err != nil {
-		return nil, fmt.Errorf("add question failed: %w", err)
-	}
-	if err := b.StartAdditionals(); err != nil {
-		return nil, fmt.Errorf("start additionals failed: %w", err)
-	}
+	
+	// Header: 12 bytes
+	buf = append(buf,
+		byte(id>>8), byte(id), // ID
+		0x01, 0x00, // Flags: RD=1
+		0x00, 0x01, // QDCOUNT=1
+		0x00, 0x00, // ANCOUNT=0
+		0x00, 0x00, // NSCOUNT=0
+		0x00, 0x01, // ARCOUNT=1 (OPT)
+	)
 
-	var rh dnsmessage.ResourceHeader
-	// Set the maximum payload size we support, as per https://datatracker.ietf.org/doc/html/rfc6891#section-4.3
-	if err := rh.SetEDNS0(maxUDPMessageSize, dnsmessage.RCodeSuccess, false); err != nil {
-		return nil, fmt.Errorf("set EDNS(0) failed: %w", err)
-	}
-	if err := b.OPTResource(rh, dnsmessage.OPTResource{}); err != nil {
-		return nil, fmt.Errorf("add OPT RR failed: %w", err)
-	}
-
-	buf, err := b.Finish()
+	// Question Section
+	var err error
+	buf, err = appendName(buf, name)
 	if err != nil {
-		return nil, fmt.Errorf("message serialization failed: %w", err)
+		return nil, fmt.Errorf("invalid question name: %w", err)
 	}
+	buf = append(buf,
+		byte(qtype>>8), byte(qtype), // QTYPE
+		0x00, 0x01, // QCLASS (INET=1)
+	)
+
+	// Additional Section (OPT)
+	// As per https://datatracker.ietf.org/doc/html/rfc6891#section-4.3
+	buf = append(buf,
+		0x00,       // Name (root, 0 bytes)
+		0x00, 41,   // Type (OPT=41)
+		byte(udpSize>>8), byte(udpSize&0xFF), // UDP payload size
+		0x00, 0x00, 0x00, 0x00, // Ext RCODE, Version, Z
+		0x00, 0x00, // RDLENGTH (0)
+	)
 	return buf, nil
 }
 
@@ -187,41 +225,74 @@ func equalASCIIName(x, y dnsmessage.Name) bool {
 	return true
 }
 
-func checkResponse(reqID uint16, reqQues dnsmessage.Question, respHdr dnsmessage.Header, respQs []dnsmessage.Question) error {
-	if !respHdr.Response {
+// checkResponseRaw verifies the DNS response matches the request parameters directly on the wire bytes.
+func checkResponseRaw(reqID uint16, name string, qtype uint16, rawResp []byte) error {
+	if len(rawResp) < 12 {
+		return errors.New("response too short for header")
+	}
+	// Check Response bit (QR) which is bit 7 of byte 2 (flags top byte)
+	if rawResp[2]&0x80 == 0 {
 		return errors.New("response bit not set")
 	}
-
+	// Check ID
 	// https://datatracker.ietf.org/doc/html/rfc5452#section-4.3
-	if reqID != respHdr.ID {
-		return fmt.Errorf("message id does not match. Expected %v, got %v", reqID, respHdr.ID)
+	respID := binary.BigEndian.Uint16(rawResp[0:2])
+	if reqID != respID {
+		return fmt.Errorf("message id does not match. Expected %v, got %v", reqID, respID)
 	}
-
+	// Check QDCOUNT (Question count)
 	// https://datatracker.ietf.org/doc/html/rfc5452#section-4.2
-	if len(respQs) == 0 {
+	qdCount := binary.BigEndian.Uint16(rawResp[4:6])
+	if qdCount == 0 {
 		return errors.New("response had no questions")
 	}
-	respQ := respQs[0]
-	if reqQues.Type != respQ.Type || reqQues.Class != respQ.Class || !equalASCIIName(reqQues.Name, respQ.Name) {
-		return errors.New("response question doesn't match request")
+
+	// Verify the first question echoes exactly our request question.
+	// We construct the expected question name dynamically to avoid allocation.
+	var expectedNameBuf [255]byte
+	expectedName, err := appendName(expectedNameBuf[:0], name)
+	if err != nil {
+		return fmt.Errorf("failed to format expected question name: %w", err)
 	}
 
+	reqQLen := len(expectedName) + 4
+	if len(rawResp) < 12+reqQLen {
+		return errors.New("response too short for echoed question")
+	}
+	
+	respQName := rawResp[12 : 12+len(expectedName)]
+
+	// Case-insensitive comparison, as the server may echo back randomized caps (e.g. 0x20 encoding)
+	for i := 0; i < len(expectedName); i++ {
+		if foldCase(expectedName[i]) != foldCase(respQName[i]) {
+			return fmt.Errorf("response question name doesn't match request. Expected %x, got %x", expectedName, respQName)
+		}
+	}
+	
+	respQType := binary.BigEndian.Uint16(rawResp[12+len(expectedName):])
+	if respQType != qtype {
+		return fmt.Errorf("response question type doesn't match request. Expected %v, got %v", qtype, respQType)
+	}
+	
+	respQClass := binary.BigEndian.Uint16(rawResp[12+len(expectedName)+2:])
+	if respQClass != uint16(dnsmessage.ClassINET) {
+		return fmt.Errorf("response question class doesn't match request. Expected %v, got %v", uint16(dnsmessage.ClassINET), respQClass)
+	}
+	
 	return nil
 }
 
 // queryDatagram implements a DNS query over a datagram protocol.
 // It validates the response ID and question echo before returning raw wire-format bytes.
-func queryDatagram(conn io.ReadWriter, name string, qtype uint16) ([]byte, error) {
+func queryDatagram(conn io.ReadWriter, name string, qtype uint16, buf []byte) ([]byte, error) {
 	// Reference: https://cs.opensource.google/go/go/+/master:src/net/dnsclient_unix.go?q=func:dnsPacketRoundTrip&ss=go%2Fgo
-	q, err := makeQuestion(name, qtype)
-	if err != nil {
-		return nil, &nestedError{ErrBadRequest, fmt.Errorf("invalid question: %w", err)}
-	}
 	id := uint16(rand.Uint32())
-	buf, err := appendRequest(id, q, make([]byte, 0, maxUDPMessageSize))
+	buf = buf[:0]
+	buf, err := appendRequestRaw(id, name, qtype, buf)
 	if err != nil {
 		return nil, &nestedError{ErrBadRequest, fmt.Errorf("append request failed: %w", err)}
 	}
+
 	if _, err := conn.Write(buf); err != nil {
 		return nil, &nestedError{ErrSend, err}
 	}
@@ -236,32 +307,31 @@ func queryDatagram(conn io.ReadWriter, name string, qtype uint16) ([]byte, error
 		if err != nil {
 			return nil, &nestedError{ErrReceive, errors.Join(returnErr, fmt.Errorf("read message failed: %w", err))}
 		}
-		var msg dnsmessage.Message
-		if err := msg.Unpack(buf[:n]); err != nil {
-			returnErr = errors.Join(returnErr, err)
-			// Ignore invalid packets that fail to parse. It could be injected.
-			continue
-		}
-		if err := checkResponse(id, q, msg.Header, msg.Questions); err != nil {
+		
+		// Ignore invalid packets that fail to parse. It could be injected.
+		if err := checkResponseRaw(id, name, qtype, buf[:n]); err != nil {
 			returnErr = errors.Join(returnErr, err)
 			continue
 		}
-		result := make([]byte, n)
-		copy(result, buf[:n])
-		return result, nil
+		
+		return buf[:n], nil
 	}
 }
 
 // queryStream implements a DNS query over a stream protocol. It frames the messages by prepending them with a 2-byte length prefix.
 // It validates the response ID and question echo before returning raw wire-format bytes.
-func queryStream(conn io.ReadWriter, name string, qtype uint16) ([]byte, error) {
+func queryStream(conn io.ReadWriter, name string, qtype uint16, buf []byte) ([]byte, error) {
 	// Reference: https://cs.opensource.google/go/go/+/master:src/net/dnsclient_unix.go?q=func:dnsStreamRoundTrip&ss=go%2Fgo
-	q, err := makeQuestion(name, qtype)
-	if err != nil {
-		return nil, &nestedError{ErrBadRequest, fmt.Errorf("invalid question: %w", err)}
-	}
 	id := uint16(rand.Uint32())
-	buf, err := appendRequest(id, q, make([]byte, 2, 514))
+	
+	// Pre-allocate 2 bytes for the length prefix, so we don't have to shift later.
+	if cap(buf) < 2 {
+		buf = make([]byte, 2, 514)
+	} else {
+		buf = buf[:2]
+		buf[0], buf[1] = 0, 0
+	}
+	buf, err := appendRequestRaw(id, name, qtype, buf)
 	if err != nil {
 		return nil, &nestedError{ErrBadRequest, err}
 	}
@@ -289,11 +359,8 @@ func queryStream(conn io.ReadWriter, name string, qtype uint16) ([]byte, error) 
 		return nil, &nestedError{ErrReceive, fmt.Errorf("read message failed: %w", err)}
 	}
 
-	var msg dnsmessage.Message
-	if err = msg.Unpack(buf); err != nil {
-		return nil, &nestedError{ErrBadResponse, fmt.Errorf("response failed to unpack: %w", err)}
-	}
-	if err := checkResponse(id, q, msg.Header, msg.Questions); err != nil {
+	// Ignore invalid packets that fail to parse. It could be injected.
+	if err := checkResponseRaw(id, name, qtype, buf); err != nil {
 		return nil, &nestedError{ErrBadResponse, err}
 	}
 	return buf, nil
@@ -317,7 +384,7 @@ func ensurePort(address string, defaultPort string) string {
 // [DNS-over-UDP]: https://datatracker.ietf.org/doc/html/rfc1035#section-4.2.1
 func NewUDPRawResolver(pd transport.PacketDialer, resolverAddr string) RawResolver {
 	resolverAddr = ensurePort(resolverAddr, "53")
-	return FuncRawResolver(func(ctx context.Context, name string, qtype uint16) ([]byte, error) {
+	return FuncRawResolver(func(ctx context.Context, name string, qtype uint16, buf []byte) ([]byte, error) {
 		conn, err := pd.DialPacket(ctx, resolverAddr)
 		if err != nil {
 			return nil, &nestedError{ErrDial, err}
@@ -326,7 +393,7 @@ func NewUDPRawResolver(pd transport.PacketDialer, resolverAddr string) RawResolv
 		if deadline, ok := ctx.Deadline(); ok {
 			conn.SetDeadline(deadline)
 		}
-		return queryDatagram(conn, name, qtype)
+		return queryDatagram(conn, name, qtype, buf)
 	})
 }
 
@@ -342,7 +409,7 @@ type streamRawResolver struct {
 	NewConn func(context.Context) (transport.StreamConn, error)
 }
 
-func (r *streamRawResolver) QueryRaw(ctx context.Context, name string, qtype uint16) ([]byte, error) {
+func (r *streamRawResolver) QueryRaw(ctx context.Context, name string, qtype uint16, buf []byte) ([]byte, error) {
 	conn, err := r.NewConn(ctx)
 	if err != nil {
 		return nil, &nestedError{ErrDial, err}
@@ -352,7 +419,7 @@ func (r *streamRawResolver) QueryRaw(ctx context.Context, name string, qtype uin
 	if deadline, ok := ctx.Deadline(); ok {
 		conn.SetDeadline(deadline)
 	}
-	return queryStream(conn, name, qtype)
+	return queryStream(conn, name, qtype, buf)
 }
 
 // NewTCPRawResolver creates a [RawResolver] that implements the [DNS-over-TCP] protocol, using a [transport.StreamDialer] for transport.
@@ -432,17 +499,15 @@ func NewHTTPSRawResolver(sd transport.StreamDialer, resolverAddr string, url str
 			ResponseHeaderTimeout: 20 * time.Second, // Same value as Android DNS-over-TLS
 		},
 	}
-	return FuncRawResolver(func(ctx context.Context, name string, qtype uint16) ([]byte, error) {
+	return FuncRawResolver(func(ctx context.Context, name string, qtype uint16, buf []byte) ([]byte, error) {
 		// Prepare request.
 		// DoH uses ID=0 per RFC 8484.
-		q, err := makeQuestion(name, qtype)
-		if err != nil {
-			return nil, &nestedError{ErrBadRequest, fmt.Errorf("invalid question: %w", err)}
-		}
-		buf, err := appendRequest(0, q, make([]byte, 0, 512))
+		buf = buf[:0]
+		buf, err := appendRequestRaw(0, name, qtype, buf)
 		if err != nil {
 			return nil, &nestedError{ErrBadRequest, err}
 		}
+
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(buf))
 		if err != nil {
 			return nil, &nestedError{ErrBadRequest, fmt.Errorf("create HTTP request failed: %w", err)}
@@ -466,11 +531,8 @@ func NewHTTPSRawResolver(sd transport.StreamDialer, resolverAddr string, url str
 		}
 
 		// Process response.
-		var msg dnsmessage.Message
-		if err = msg.Unpack(response); err != nil {
-			return nil, &nestedError{ErrBadResponse, fmt.Errorf("failed to unpack DNS response: %w", err)}
-		}
-		if err := checkResponse(0, q, msg.Header, msg.Questions); err != nil {
+		// Ignore invalid packets that fail to parse. It could be injected.
+		if err := checkResponseRaw(0, name, qtype, response); err != nil {
 			return nil, &nestedError{ErrBadResponse, err}
 		}
 		return response, nil

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -129,32 +129,50 @@ func NewQuestion(domain string, qtype dnsmessage.Type) (*dnsmessage.Question, er
 const maxUDPMessageSize = 1232
 
 // appendName splits a dot-separated domain name into DNS wire-format labels and appends them to buf.
+// It supports escaping characters using a backslash.
 func appendName(buf []byte, name string) ([]byte, error) {
 	if len(name) > 0 && name[len(name)-1] == '.' {
-		name = name[:len(name)-1]
+		// Only strip the last dot if it's not escaped
+		if len(name) < 2 || name[len(name)-2] != '\\' {
+			name = name[:len(name)-1]
+		}
 	}
 	if len(name) == 0 {
 		return append(buf, 0), nil
 	}
 	startLength := len(buf)
+	
 	for len(name) > 0 {
-		idx := strings.IndexByte(name, '.')
-		var label string
-		if idx == -1 {
-			label = name
-			name = ""
-		} else {
-			label = name[:idx]
-			name = name[idx+1:]
+		buf = append(buf, 0) // Placeholder for label length
+		lblStart := len(buf)
+		
+		idx := -1
+		for i := 0; i < len(name); i++ {
+			if name[i] == '.' {
+				idx = i
+				break
+			} else if name[i] == '\\' && i+1 < len(name) {
+				i++
+				buf = append(buf, name[i])
+			} else {
+				buf = append(buf, name[i])
+			}
 		}
-		if len(label) == 0 {
+		
+		lblLen := len(buf) - lblStart
+		if lblLen == 0 {
 			return nil, errors.New("empty label")
 		}
-		if len(label) > 63 {
+		if lblLen > 63 {
 			return nil, errors.New("label too long")
 		}
-		buf = append(buf, byte(len(label)))
-		buf = append(buf, label...)
+		buf[lblStart-1] = byte(lblLen) // Write the correct length
+
+		if idx == -1 {
+			name = ""
+		} else {
+			name = name[idx+1:]
+		}
 	}
 	buf = append(buf, 0)
 	if len(buf)-startLength > 255 {

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -525,18 +525,42 @@ func NewHTTPSRawResolver(sd transport.StreamDialer, resolverAddr string, url str
 		if httpResp.StatusCode != http.StatusOK {
 			return nil, &nestedError{ErrReceive, fmt.Errorf("got HTTP status %v", httpResp.StatusCode)}
 		}
-		response, err := io.ReadAll(httpResp.Body)
+		buf, err = readAllInto(httpResp.Body, buf, httpResp.ContentLength)
 		if err != nil {
 			return nil, &nestedError{ErrReceive, fmt.Errorf("failed to read response: %w", err)}
 		}
 
 		// Process response.
 		// Ignore invalid packets that fail to parse. It could be injected.
-		if err := checkResponseRaw(0, name, qtype, response); err != nil {
+		if err := checkResponseRaw(0, name, qtype, buf); err != nil {
 			return nil, &nestedError{ErrBadResponse, err}
 		}
-		return response, nil
+		return buf, nil
 	})
+}
+
+// readAllInto reads everything from r into buf, reusing its capacity.
+// It pre-grows the buffer if expectedSize is known and reasonable for DNS.
+func readAllInto(r io.Reader, buf []byte, expectedSize int64) ([]byte, error) {
+	buf = buf[:0]
+	// Pre-grow buffer if we know the size and it's reasonable for DNS (< 64KB).
+	if expectedSize > 0 && expectedSize <= 65535 && int64(cap(buf)) < expectedSize {
+		buf = make([]byte, 0, expectedSize)
+	}
+	for {
+		if len(buf) == cap(buf) {
+			buf = append(buf, 0)[:len(buf)]
+		}
+		n, err := r.Read(buf[len(buf):cap(buf)])
+		buf = buf[:len(buf)+n]
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return buf, err
+		}
+	}
+	return buf, nil
 }
 
 // NewHTTPSResolver creates a [Resolver] that implements the [DNS-over-HTTPS] protocol, using a [transport.StreamDialer]

--- a/dns/resolver_test.go
+++ b/dns/resolver_test.go
@@ -73,12 +73,11 @@ func TestNewQuestionLongName(t *testing.T) {
 }
 
 func Test_appendRequest(t *testing.T) {
-	q, err := NewQuestion(".", dnsmessage.TypeAAAA)
-	require.NoError(t, err)
-
 	id := uint16(1234)
 	offset := 2
-	buf, err := appendRequest(id, *q, make([]byte, offset))
+	q, err := makeQuestion(".", uint16(dnsmessage.TypeAAAA))
+	require.NoError(t, err)
+	buf, err := appendRequest(id, q, make([]byte, offset))
 	require.NoError(t, err)
 	require.Equal(t, make([]byte, offset), buf[:offset])
 
@@ -92,7 +91,9 @@ func Test_appendRequest(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, request.ID)
 	require.Equal(t, 1, len(request.Questions))
-	require.Equal(t, *q, request.Questions[0])
+	expectedQ, err := NewQuestion(".", dnsmessage.TypeAAAA)
+	require.NoError(t, err)
+	require.Equal(t, *expectedQ, request.Questions[0])
 	require.Equal(t, 0, len(request.Answers))
 	require.Equal(t, 0, len(request.Authorities))
 	// ENDS(0) OPT resource record.
@@ -128,55 +129,56 @@ func Test_equalASCIIName(t *testing.T) {
 
 func Test_checkResponse(t *testing.T) {
 	reqID := uint16(rand.Uint32())
-	reqQ := dnsmessage.Question{
-		Name:  dnsmessage.MustNewName("example.com."),
-		Type:  dnsmessage.TypeAAAA,
+	const reqName = "example.com."
+	const reqType = dnsmessage.TypeAAAA
+	matchQ := dnsmessage.Question{
+		Name:  dnsmessage.MustNewName(reqName),
+		Type:  reqType,
 		Class: dnsmessage.ClassINET,
 	}
 	expectedHdr := dnsmessage.Header{ID: reqID, Response: true}
-	expectedQs := []dnsmessage.Question{reqQ}
 	t.Run("Match", func(t *testing.T) {
-		err := checkResponse(reqID, reqQ, expectedHdr, expectedQs)
+		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{matchQ})
 		require.NoError(t, err)
 	})
 	t.Run("CaseInsensitive", func(t *testing.T) {
-		mixedQ := reqQ
+		mixedQ := matchQ
 		mixedQ.Name = dnsmessage.MustNewName("Example.Com.")
-		err := checkResponse(reqID, reqQ, expectedHdr, []dnsmessage.Question{mixedQ})
+		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{mixedQ})
 		require.NoError(t, err)
 	})
 	t.Run("NotResponse", func(t *testing.T) {
 		badHdr := expectedHdr
 		badHdr.Response = false
-		err := checkResponse(reqID, reqQ, badHdr, expectedQs)
+		err := checkResponse(reqID, matchQ, badHdr, []dnsmessage.Question{matchQ})
 		require.Error(t, err)
 	})
 	t.Run("BadID", func(t *testing.T) {
 		badHdr := expectedHdr
 		badHdr.ID = reqID + 1
-		err := checkResponse(reqID, reqQ, badHdr, expectedQs)
+		err := checkResponse(reqID, matchQ, badHdr, []dnsmessage.Question{matchQ})
 		require.Error(t, err)
 	})
 	t.Run("NoQuestions", func(t *testing.T) {
-		err := checkResponse(reqID, reqQ, expectedHdr, []dnsmessage.Question{})
+		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{})
 		require.Error(t, err)
 	})
 	t.Run("BadQuestionType", func(t *testing.T) {
-		badQ := reqQ
+		badQ := matchQ
 		badQ.Type = dnsmessage.TypeA
-		err := checkResponse(reqID, reqQ, expectedHdr, []dnsmessage.Question{badQ})
+		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{badQ})
 		require.Error(t, err)
 	})
 	t.Run("BadQuestionClass", func(t *testing.T) {
-		badQ := reqQ
+		badQ := matchQ
 		badQ.Class = dnsmessage.ClassCHAOS
-		err := checkResponse(reqID, reqQ, expectedHdr, []dnsmessage.Question{badQ})
+		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{badQ})
 		require.Error(t, err)
 	})
 	t.Run("BadQuestionName", func(t *testing.T) {
-		badQ := reqQ
+		badQ := matchQ
 		badQ.Name = dnsmessage.MustNewName("notexample.invalid.")
-		err := checkResponse(reqID, reqQ, expectedHdr, []dnsmessage.Question{badQ})
+		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{badQ})
 		require.Error(t, err)
 	})
 }
@@ -200,18 +202,16 @@ func newMessageResponse(req dnsmessage.Message, answer dnsmessage.ResourceBody, 
 }
 
 type queryResult struct {
-	msg *dnsmessage.Message
-	err error
+	data []byte
+	err  error
 }
 
-func testDatagramExchange(t *testing.T, server func(request dnsmessage.Message, conn net.Conn)) (*dnsmessage.Message, error) {
+func testDatagramExchange(t *testing.T, server func(request dnsmessage.Message, conn net.Conn)) ([]byte, error) {
 	front, back := net.Pipe()
-	q, err := NewQuestion("example.com.", dnsmessage.TypeAAAA)
-	require.NoError(t, err)
 	clientDone := make(chan queryResult)
 	go func() {
-		msg, err := queryDatagram(front, *q)
-		clientDone <- queryResult{msg, err}
+		data, err := queryDatagram(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+		clientDone <- queryResult{data, err}
 	}()
 	// Read request.
 	buf := make([]byte, 512)
@@ -222,20 +222,22 @@ func testDatagramExchange(t *testing.T, server func(request dnsmessage.Message, 
 	var reqMsg dnsmessage.Message
 	reqMsg.Unpack(buf)
 	reqID := reqMsg.ID
-	expectedBuf, err := appendRequest(reqID, *q, make([]byte, 0, 512))
+	expectedQ, err := makeQuestion("example.com.", uint16(dnsmessage.TypeAAAA))
+	require.NoError(t, err)
+	expectedBuf, err := appendRequest(reqID, expectedQ, make([]byte, 0, 512))
 	require.NoError(t, err)
 	require.Equal(t, expectedBuf, buf)
 
 	server(reqMsg, back)
 
 	result := <-clientDone
-	return result.msg, result.err
+	return result.data, result.err
 }
 
 func Test_queryDatagram(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var respSent dnsmessage.Message
-		respRcvd, err := testDatagramExchange(t, func(req dnsmessage.Message, conn net.Conn) {
+		rawResp, err := testDatagramExchange(t, func(req dnsmessage.Message, conn net.Conn) {
 			// Send bogus response.
 			_, err := conn.Write([]byte{0, 0})
 			require.NoError(t, err)
@@ -259,8 +261,10 @@ func Test_queryDatagram(t *testing.T) {
 			require.NoError(t, err)
 		})
 		require.NoError(t, err)
-		require.NotNil(t, respRcvd)
-		require.Equal(t, respSent, *respRcvd)
+		require.NotNil(t, rawResp)
+		var respRcvd dnsmessage.Message
+		require.NoError(t, respRcvd.Unpack(rawResp))
+		require.Equal(t, respSent, respRcvd)
 	})
 	t.Run("BadResponse", func(t *testing.T) {
 		_, err := testDatagramExchange(t, func(req dnsmessage.Message, conn net.Conn) {
@@ -277,12 +281,10 @@ func Test_queryDatagram(t *testing.T) {
 	t.Run("FailedClientWrite", func(t *testing.T) {
 		front, back := net.Pipe()
 		back.Close()
-		q, err := NewQuestion("example.com.", dnsmessage.TypeAAAA)
-		require.NoError(t, err)
 		clientDone := make(chan queryResult)
 		go func() {
-			msg, err := queryDatagram(front, *q)
-			clientDone <- queryResult{msg, err}
+			data, err := queryDatagram(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+			clientDone <- queryResult{data, err}
 		}()
 		// Wait for queryDatagram.
 		result := <-clientDone
@@ -291,12 +293,10 @@ func Test_queryDatagram(t *testing.T) {
 	})
 	t.Run("FailedClientRead", func(t *testing.T) {
 		front, back := net.Pipe()
-		q, err := NewQuestion("example.com.", dnsmessage.TypeAAAA)
-		require.NoError(t, err)
 		clientDone := make(chan queryResult)
 		go func() {
-			msg, err := queryDatagram(front, *q)
-			clientDone <- queryResult{msg, err}
+			data, err := queryDatagram(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+			clientDone <- queryResult{data, err}
 		}()
 		back.Read(make([]byte, 521))
 		back.Close()
@@ -307,14 +307,12 @@ func Test_queryDatagram(t *testing.T) {
 	})
 }
 
-func testStreamExchange(t *testing.T, server func(request dnsmessage.Message, conn net.Conn)) (*dnsmessage.Message, error) {
+func testStreamExchange(t *testing.T, server func(request dnsmessage.Message, conn net.Conn)) ([]byte, error) {
 	front, back := net.Pipe()
-	q, err := NewQuestion("example.com.", dnsmessage.TypeAAAA)
-	require.NoError(t, err)
 	clientDone := make(chan queryResult)
 	go func() {
-		msg, err := queryStream(front, *q)
-		clientDone <- queryResult{msg, err}
+		data, err := queryStream(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+		clientDone <- queryResult{data, err}
 	}()
 	// Read request.
 	var msgLen uint16
@@ -327,20 +325,22 @@ func testStreamExchange(t *testing.T, server func(request dnsmessage.Message, co
 	var reqMsg dnsmessage.Message
 	reqMsg.Unpack(buf)
 	reqID := reqMsg.ID
-	expectedBuf, err := appendRequest(reqID, *q, make([]byte, 0, 512))
+	expectedQ, err := makeQuestion("example.com.", uint16(dnsmessage.TypeAAAA))
+	require.NoError(t, err)
+	expectedBuf, err := appendRequest(reqID, expectedQ, make([]byte, 0, 512))
 	require.NoError(t, err)
 	require.Equal(t, expectedBuf, buf)
 
 	server(reqMsg, back)
 
 	result := <-clientDone
-	return result.msg, result.err
+	return result.data, result.err
 }
 
 func Test_queryStream(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var respSent dnsmessage.Message
-		respRcvd, err := testStreamExchange(t, func(req dnsmessage.Message, conn net.Conn) {
+		rawResp, err := testStreamExchange(t, func(req dnsmessage.Message, conn net.Conn) {
 			var err error
 			// Prepare response message.
 			respSent, err = newMessageResponse(req, &dnsmessage.AAAAResource{AAAA: [16]byte(net.IPv6loopback)}, 100)
@@ -354,8 +354,10 @@ func Test_queryStream(t *testing.T) {
 			require.NoError(t, err)
 		})
 		require.NoError(t, err)
-		require.NotNil(t, respRcvd)
-		require.Equal(t, respSent, *respRcvd)
+		require.NotNil(t, rawResp)
+		var respRcvd dnsmessage.Message
+		require.NoError(t, respRcvd.Unpack(rawResp))
+		require.Equal(t, respSent, respRcvd)
 	})
 	t.Run("ShortRead", func(t *testing.T) {
 		_, err := testStreamExchange(t, func(req dnsmessage.Message, conn net.Conn) {
@@ -412,12 +414,10 @@ func Test_queryStream(t *testing.T) {
 	t.Run("FailedClientWrite", func(t *testing.T) {
 		front, back := net.Pipe()
 		back.Close()
-		q, err := NewQuestion("example.com.", dnsmessage.TypeAAAA)
-		require.NoError(t, err)
 		clientDone := make(chan queryResult)
 		go func() {
-			msg, err := queryStream(front, *q)
-			clientDone <- queryResult{msg, err}
+			data, err := queryStream(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+			clientDone <- queryResult{data, err}
 		}()
 		// Wait for client.
 		result := <-clientDone
@@ -426,12 +426,10 @@ func Test_queryStream(t *testing.T) {
 	})
 	t.Run("FailedClientRead", func(t *testing.T) {
 		front, back := net.Pipe()
-		q, err := NewQuestion("example.com.", dnsmessage.TypeAAAA)
-		require.NoError(t, err)
 		clientDone := make(chan queryResult)
 		go func() {
-			msg, err := queryStream(front, *q)
-			clientDone <- queryResult{msg, err}
+			data, err := queryStream(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+			clientDone <- queryResult{data, err}
 		}()
 		back.Read(make([]byte, 521))
 		back.Close()

--- a/dns/resolver_test.go
+++ b/dns/resolver_test.go
@@ -72,6 +72,31 @@ func TestNewQuestionLongName(t *testing.T) {
 	require.Error(t, err)
 }
 
+func Test_appendName(t *testing.T) {
+	serialize := func(domain string) []byte {
+		buf, err := appendName(nil, domain)
+		require.NoError(t, err)
+		return buf
+	}
+	serializeErr := func(domain string) {
+		_, err := appendName(nil, domain)
+		require.Error(t, err)
+	}
+
+	require.Equal(t, []byte("\x00"), serialize(""), "Empty")
+	require.Equal(t, []byte("\x00"), serialize("."), "Root")
+	require.Equal(t, []byte("\x07example\x03com\x00"), serialize("example.com."), "FQDN")
+	require.Equal(t, []byte("\x07example\x03com\x00"), serialize("example.com"), "NoTrailingDot")
+	require.Equal(t, []byte("\x07foo.bar\x03com\x00"), serialize("foo\\.bar.com."), "DotInLabel")
+	require.Equal(t, []byte("\x07foo\\bar\x03com\x00"), serialize("foo\\\\bar.com."), "BackslashInLabel")
+	
+	require.Equal(t, append(append([]byte{63}, strings.Repeat("a", 63)...), []byte("\x03com\x00")...), serialize(strings.Repeat("a", 63)+".com."), "MaxLengthLabel")
+
+	serializeErr(strings.Repeat("a", 64) + ".com") // LongLabel
+	serializeErr("example..com")                   // EmptyLabel
+	serializeErr(strings.Repeat("a.", 128))        // NameTooLong
+}
+
 func Test_appendRequestRaw(t *testing.T) {
 	id := uint16(1234)
 	offset := 2

--- a/dns/resolver_test.go
+++ b/dns/resolver_test.go
@@ -72,12 +72,10 @@ func TestNewQuestionLongName(t *testing.T) {
 	require.Error(t, err)
 }
 
-func Test_appendRequest(t *testing.T) {
+func Test_appendRequestRaw(t *testing.T) {
 	id := uint16(1234)
 	offset := 2
-	q, err := makeQuestion(".", uint16(dnsmessage.TypeAAAA))
-	require.NoError(t, err)
-	buf, err := appendRequest(id, q, make([]byte, offset))
+	buf, err := appendRequestRaw(id, ".", uint16(dnsmessage.TypeAAAA), make([]byte, offset, maxUDPMessageSize))
 	require.NoError(t, err)
 	require.Equal(t, make([]byte, offset), buf[:offset])
 
@@ -127,58 +125,49 @@ func Test_equalASCIIName(t *testing.T) {
 	require.False(t, equalASCIIName(dnsmessage.MustNewName("example.com"), dnsmessage.MustNewName("myexample.com")))
 }
 
-func Test_checkResponse(t *testing.T) {
+func Test_checkResponseRaw(t *testing.T) {
 	reqID := uint16(rand.Uint32())
 	const reqName = "example.com."
 	const reqType = dnsmessage.TypeAAAA
-	matchQ := dnsmessage.Question{
-		Name:  dnsmessage.MustNewName(reqName),
-		Type:  reqType,
-		Class: dnsmessage.ClassINET,
+	
+	makeResp := func(id uint16, respBit bool, qname string, qtype dnsmessage.Type) []byte {
+		buf, _ := appendRequestRaw(id, qname, uint16(qtype), nil)
+		if respBit {
+			buf[2] |= 0x80
+		}
+		return buf
 	}
-	expectedHdr := dnsmessage.Header{ID: reqID, Response: true}
+
 	t.Run("Match", func(t *testing.T) {
-		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{matchQ})
+		err := checkResponseRaw(reqID, reqName, uint16(reqType), makeResp(reqID, true, reqName, reqType))
 		require.NoError(t, err)
 	})
 	t.Run("CaseInsensitive", func(t *testing.T) {
-		mixedQ := matchQ
-		mixedQ.Name = dnsmessage.MustNewName("Example.Com.")
-		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{mixedQ})
+		err := checkResponseRaw(reqID, reqName, uint16(reqType), makeResp(reqID, true, "Example.Com.", reqType))
 		require.NoError(t, err)
 	})
 	t.Run("NotResponse", func(t *testing.T) {
-		badHdr := expectedHdr
-		badHdr.Response = false
-		err := checkResponse(reqID, matchQ, badHdr, []dnsmessage.Question{matchQ})
+		err := checkResponseRaw(reqID, reqName, uint16(reqType), makeResp(reqID, false, reqName, reqType))
 		require.Error(t, err)
 	})
 	t.Run("BadID", func(t *testing.T) {
-		badHdr := expectedHdr
-		badHdr.ID = reqID + 1
-		err := checkResponse(reqID, matchQ, badHdr, []dnsmessage.Question{matchQ})
+		err := checkResponseRaw(reqID, reqName, uint16(reqType), makeResp(reqID+1, true, reqName, reqType))
 		require.Error(t, err)
 	})
 	t.Run("NoQuestions", func(t *testing.T) {
-		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{})
+		raw := makeResp(reqID, true, reqName, reqType)
+		// set QDCOUNT to 0
+		raw[4] = 0
+		raw[5] = 0
+		err := checkResponseRaw(reqID, reqName, uint16(reqType), raw)
 		require.Error(t, err)
 	})
 	t.Run("BadQuestionType", func(t *testing.T) {
-		badQ := matchQ
-		badQ.Type = dnsmessage.TypeA
-		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{badQ})
-		require.Error(t, err)
-	})
-	t.Run("BadQuestionClass", func(t *testing.T) {
-		badQ := matchQ
-		badQ.Class = dnsmessage.ClassCHAOS
-		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{badQ})
+		err := checkResponseRaw(reqID, reqName, uint16(reqType), makeResp(reqID, true, reqName, dnsmessage.TypeA))
 		require.Error(t, err)
 	})
 	t.Run("BadQuestionName", func(t *testing.T) {
-		badQ := matchQ
-		badQ.Name = dnsmessage.MustNewName("notexample.invalid.")
-		err := checkResponse(reqID, matchQ, expectedHdr, []dnsmessage.Question{badQ})
+		err := checkResponseRaw(reqID, reqName, uint16(reqType), makeResp(reqID, true, "notexample.invalid.", reqType))
 		require.Error(t, err)
 	})
 }
@@ -210,7 +199,7 @@ func testDatagramExchange(t *testing.T, server func(request dnsmessage.Message, 
 	front, back := net.Pipe()
 	clientDone := make(chan queryResult)
 	go func() {
-		data, err := queryDatagram(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+		data, err := queryDatagram(front, "example.com.", uint16(dnsmessage.TypeAAAA), make([]byte, 0, maxUDPMessageSize))
 		clientDone <- queryResult{data, err}
 	}()
 	// Read request.
@@ -222,9 +211,7 @@ func testDatagramExchange(t *testing.T, server func(request dnsmessage.Message, 
 	var reqMsg dnsmessage.Message
 	reqMsg.Unpack(buf)
 	reqID := reqMsg.ID
-	expectedQ, err := makeQuestion("example.com.", uint16(dnsmessage.TypeAAAA))
-	require.NoError(t, err)
-	expectedBuf, err := appendRequest(reqID, expectedQ, make([]byte, 0, 512))
+	expectedBuf, err := appendRequestRaw(reqID, "example.com.", uint16(dnsmessage.TypeAAAA), make([]byte, 0, maxUDPMessageSize))
 	require.NoError(t, err)
 	require.Equal(t, expectedBuf, buf)
 
@@ -283,7 +270,7 @@ func Test_queryDatagram(t *testing.T) {
 		back.Close()
 		clientDone := make(chan queryResult)
 		go func() {
-			data, err := queryDatagram(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+			data, err := queryDatagram(front, "example.com.", uint16(dnsmessage.TypeAAAA), make([]byte, 0, 512))
 			clientDone <- queryResult{data, err}
 		}()
 		// Wait for queryDatagram.
@@ -295,7 +282,7 @@ func Test_queryDatagram(t *testing.T) {
 		front, back := net.Pipe()
 		clientDone := make(chan queryResult)
 		go func() {
-			data, err := queryDatagram(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+			data, err := queryDatagram(front, "example.com.", uint16(dnsmessage.TypeAAAA), make([]byte, 0, 512))
 			clientDone <- queryResult{data, err}
 		}()
 		back.Read(make([]byte, 521))
@@ -311,7 +298,7 @@ func testStreamExchange(t *testing.T, server func(request dnsmessage.Message, co
 	front, back := net.Pipe()
 	clientDone := make(chan queryResult)
 	go func() {
-		data, err := queryStream(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+		data, err := queryStream(front, "example.com.", uint16(dnsmessage.TypeAAAA), make([]byte, 2, 514))
 		clientDone <- queryResult{data, err}
 	}()
 	// Read request.
@@ -325,9 +312,7 @@ func testStreamExchange(t *testing.T, server func(request dnsmessage.Message, co
 	var reqMsg dnsmessage.Message
 	reqMsg.Unpack(buf)
 	reqID := reqMsg.ID
-	expectedQ, err := makeQuestion("example.com.", uint16(dnsmessage.TypeAAAA))
-	require.NoError(t, err)
-	expectedBuf, err := appendRequest(reqID, expectedQ, make([]byte, 0, 512))
+	expectedBuf, err := appendRequestRaw(reqID, "example.com.", uint16(dnsmessage.TypeAAAA), make([]byte, 0, 514))
 	require.NoError(t, err)
 	require.Equal(t, expectedBuf, buf)
 
@@ -416,7 +401,7 @@ func Test_queryStream(t *testing.T) {
 		back.Close()
 		clientDone := make(chan queryResult)
 		go func() {
-			data, err := queryStream(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+			data, err := queryStream(front, "example.com.", uint16(dnsmessage.TypeAAAA), make([]byte, 2, 514))
 			clientDone <- queryResult{data, err}
 		}()
 		// Wait for client.
@@ -428,7 +413,7 @@ func Test_queryStream(t *testing.T) {
 		front, back := net.Pipe()
 		clientDone := make(chan queryResult)
 		go func() {
-			data, err := queryStream(front, "example.com.", uint16(dnsmessage.TypeAAAA))
+			data, err := queryStream(front, "example.com.", uint16(dnsmessage.TypeAAAA), make([]byte, 2, 514))
 			clientDone <- queryResult{data, err}
 		}()
 		back.Read(make([]byte, 521))


### PR DESCRIPTION
# Motivation

The main goal here is to decouple this foundational piece from the DNS parsing library. I've had a few issues with `dns.Resolver` while working on ECH research:

* dnsmessage fails to parse DNS labels with dots in it, which is used in the email field of SOA records.
* dnsmessage may not support the latest record types. In my case, it didn't support the HTTPS and SVCB records.
 
I ended up forced to use miekg's library instead of the SDK for that work.

This decoupling will allow the user to use whatever parsing library they prefer.

It also streamlines the implementation of the system resolver, removing unnecessary transformations when we fetch a `[]byte` response from the system APIs. See https://github.com/OutlineFoundation/outline-sdk/pull/592 for where I'm going.

The new interface takes the output buffer as input, which lets the caller control the lifecycle of the buffer and avoid unnecessary allocations.

I also want this to be a building block for the [dnstt implementation](https://github.com/OutlineFoundation/outline-sdk/discussions/574).

# Changes

The new API includes:
* `RawResolver` (takes QNAME + QTYPE + output buffer)
* `FuncRawResolver` - convenience `func` -> `RawResolver` adaptor
* `RawToResolver` - convenience adaptor to map to the current interface.
